### PR TITLE
Fixes bug: screen numbering has changed in new X11 versions

### DIFF
--- a/lib/hrl.py
+++ b/lib/hrl.py
@@ -83,13 +83,15 @@ class HRL:
         # in older versions (including lab computer), it is  ':0.1'
         #os.environ['DISPLAY'] = ':0.' + str(scrn)
         #
-        print ("OS display number: %s" % os.environ['DISPLAY'])
+        print ("OS display number (default): %s" % os.environ['DISPLAY'])
         
         if len(os.environ['DISPLAY'])>2:
             os.environ['DISPLAY'] = ':0.' + str(scrn)
         else: # legacy option for older configs
             os.environ['DISPLAY'] = ':' + str(scrn)
-            
+        
+        print ("OS display number (now used): %s" % os.environ['DISPLAY'])
+
         #######
         
         ## Load Datapixx ##

--- a/lib/hrl.py
+++ b/lib/hrl.py
@@ -76,8 +76,14 @@ class HRL:
         #data_files=[(os.path.expanduser('~/.config'), ['misc/hrlrc'])]
         #cfg = cp.RawConfigParser()
         #cfg.read([os.path.expanduser('~/.config/hrlrc')])
-        os.environ['DISPLAY'] = ':0.' + str(scrn)
-
+        
+        #######
+        # 30.Aug 2020: this command is commented as it doesnt work in newer versions of linux
+        # in the lab computer it will still have to work
+        # os.environ['DISPLAY'] = ':0.' + str(scrn)
+        print ("OS display number: %s" % os.environ['DISPLAY'])
+        #######
+        
         ## Load Datapixx ##
 
         if (graphics == 'datapixx') or (inputs == 'responsepixx'):

--- a/lib/hrl.py
+++ b/lib/hrl.py
@@ -79,9 +79,17 @@ class HRL:
         
         #######
         # 30.Aug 2020: this command is commented as it doesnt work in newer versions of linux
-        # in the lab computer it will still have to work
-        # os.environ['DISPLAY'] = ':0.' + str(scrn)
+        # in newer versions, default screen numbering is ':1'
+        # in older versions (including lab computer), it is  ':0.1'
+        #os.environ['DISPLAY'] = ':0.' + str(scrn)
+        #
         print ("OS display number: %s" % os.environ['DISPLAY'])
+        
+        if len(os.environ['DISPLAY'])>2:
+            os.environ['DISPLAY'] = ':0.' + str(scrn)
+        else: # legacy option for older configs
+            os.environ['DISPLAY'] = ':' + str(scrn)
+            
         #######
         
         ## Load Datapixx ##

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,13 @@ if __name__ == '__main__':
     distutils.core.setup(
         name='hrl',
         description='Library for designing psychophysics experiments',
-        version='0.7',
+        version='0.8',
         author='Sacha Sokoloski',
         author_email='sacha@cs.toronto.edu',
+        maintainer='Guillermo Aguilar',
+        maintainer_email='guillermo.aguilar@tu-berlin.de',
         license='GPL2',
-        url='https://github.com/TUBvision/hrl',
+        url='https://github.com/computational-psychology/hrl',
         package_dir = {'hrl' : 'lib', 'hrl.util' : 'bin/util'},
         packages=('hrl','hrl.graphics','hrl.inputs','hrl.photometer'
             ,'hrl.util','hrl.util.tests','hrl.util.lut'),


### PR DESCRIPTION
Now HRL automatically recognizes if you're in an old or new screen numbering format (X11) and sets the desired screen number accordingly. 