### PR TITLE
bugfix: textures were not being deleted in some systems

### DIFF
--- a/hrl/__init__.py
+++ b/hrl/__init__.py
@@ -22,6 +22,6 @@ pydoc hrl.photometer.minolta - Help for using a Minolta device
 pydoc hrl.photometer.optical - Help for using an OptiCAL device
 """
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 from .hrl import HRL

--- a/hrl/graphics/texture.py
+++ b/hrl/graphics/texture.py
@@ -74,16 +74,18 @@ class Texture:
 
         opengl.glCallList(self._dlid)
 
-    # JV: Why are we not using this automatic __del__ method?
-    # GA: Python's garbage collection was not working properly somehow,
-    # that's why I explicitly called the functions to delete textures.
-    def __del__(self):
-        self.delete()
+    #def __del__(self):
+    #    self.delete()
+    
+    # We do not implement the __del__ function, because
+    # it gives problems upon garbage collection at closing of python
+    # Instead, we give to the user the posibility to delete textures,
+    # particularly necessary for experiments with lots of stimuli
         
     def delete(self):
         """Remove this texture from the OpenGL texture memory"""
         if self._txid != None:
-            opengl.glDeleteTextures(self._txid)
+            opengl.glDeleteTextures(1, [self._txid])
             self._txid = None
         if self._dlid != None:
             opengl.glDeleteLists(self._dlid, 1)


### PR DESCRIPTION
Fixes a bug in HRL related to texture deletion.

We implemented the __del__ method for textures, so that it would work with python garbage collection. This however gave errors in Window systems, and in Linux systems when a script finished.
I replicated the error in Linux machines with one of our tests

hrl-util tests standard

finishing the demo will give the error:

```
Unable to import OpenGL.arrays.numpymodule.NumpyHandler: sys.meta_path is None, Python is likely shutting down
dict_keys([<class 'numpy.ndarray'>, <class 'bytes'>])
Exception ignored in: <function Texture.__del__ at 0x7fe6474f7dc0>
Traceback (most recent call last):
  File "/home/guille/git/hrl/hrl/graphics/texture.py", line 81, in __del__
  File "/home/guille/git/hrl/hrl/graphics/texture.py", line 86, in delete
  File "/home/guille/anaconda3/envs/hrl3-dev/lib/python3.8/site-packages/OpenGL/latebind.py", line 63, in __call__
  File "/home/guille/anaconda3/envs/hrl3-dev/lib/python3.8/site-packages/OpenGL/GL/exceptional.py", line 59, in glDeleteTextures
  File "/home/guille/anaconda3/envs/hrl3-dev/lib/python3.8/site-packages/OpenGL/arrays/arraydatatype.py", line 171, in asArray
  File "/home/guille/anaconda3/envs/hrl3-dev/lib/python3.8/site-packages/OpenGL/arrays/arraydatatype.py", line 59, in __call__
TypeError: No array-type handler for type numpy.uint32 (value: 1) registered

```

I have solved the bug by removing the __del__ method completely. 

Now the user should manually delete the textures when s/he needs it. This makes sense only on experiments with lots of stimuli.
