### PR TITLE
Photometer tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         # Run testing through pytest for the current version
         # uv automatically install all required dependencies from pyproject.toml
       - name: Test, for py==${{ matrix.python_version }}
-        run: uv run pytest tests/ -m "not graphics"
+        run: uv run pytest tests/ -m "not graphics and not photometer"

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,27 @@
+# Python cache
+__pycache__/
 *.pyc
+
+# Build artifacts
 build/
 hrl.egg-info/
+
+# Documentation build artifacts
 docs/_build/
 
+
+## Tool specifics:
+# Cached files for pytest
+.pytest_cache/
+
+# Directory for virtual environment
+.venv/
+
+# Cache files for mypy type checker
+.mypy_cache/
+
+# Lock file for uv package manager
 uv.lock
 
-.vscode/settings.json
+# Settings for VSCode editor
+.vscode/

--- a/hrl/util/__init__.py
+++ b/hrl/util/__init__.py
@@ -23,31 +23,7 @@ def main():
         )
 
     else:
-        if args[0] == "tests":
-            if len(args) == 1 or args[1] == "--help":
-                print(
-                    """
-        Tests are simple scripts to ensure that HRL software and hardware
-        is working correctly.
-
-        Currently implemented commands are:
-
-            standard - Basic test for a normal computer
-            datapixx - Basic test for a computer with DATApixx
-            optical - Take a single reading from an OptiCAL
-            class - Tests the HRL class with normal hardware
-                """
-                )
-            elif args[1] == "standard":
-                import hrl.util.tests.standard
-            elif args[1] == "datapixx":
-                import hrl.util.tests.datapixx
-            elif args[1] == "optical":
-                import hrl.util.tests.optical
-            elif args[1] == "class":
-                import hrl.util.tests.classtest
-
-        elif args[0] == "lut":
+        if args[0] == "lut":
             if len(args) == 1 or args[1] == "--help":
                 print(
                     """

--- a/hrl/util/tests/optical.py
+++ b/hrl/util/tests/optical.py
@@ -1,9 +1,0 @@
-from hrl.photometer.optical import OptiCAL
-
-import numpy as np
-import pygame as pg
-import time
-
-
-phtm = OptiCAL("/dev/ttyUSB0")
-print("\nLuminance: " + str(phtm.readLuminance(5, 5)) + "\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ markers = [
     "inputs: mark test as requiring input.",
     "interactive: mark test as interactive.",
     "pixx: mark test as requiring DataPixx or ViewPixx hardware.",
+    "photometer: mark test as requiring a photometer.",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,25 @@ from hrl.luts import create_clut, create_lut
 DEFAULT_GAMMA = 2.2
 
 
+def pytest_addoption(parser):
+    """Add custom command-line options for pytest."""
+    parser.addoption(
+        "--photometer-dev",
+        action="store",
+        default="/dev/ttyUSB0",
+        help="Device path for photometer (default: /dev/ttyUSB0)",
+    )
+
+
+@pytest.fixture
+def photometer_dev(request):
+    """Get the photometer device path from command-line or use default.
+
+    Can be overridden with: pytest --photometer-dev=/dev/ttyUSB1
+    """
+    return request.config.getoption("--photometer-dev")
+
+
 @pytest.fixture
 def no_lut():
     """Simple pass-through LUT with no gamma correction and no dark luminance.

--- a/tests/test_minolta.py
+++ b/tests/test_minolta.py
@@ -1,0 +1,13 @@
+import pytest
+
+from hrl.photometer.minolta import Minolta
+
+pytestmark = [pytest.mark.photometer]
+
+
+def test_initialization():
+    Minolta(dev="/dev/ttyUSB0")
+
+
+def test_read_luminance():
+    Minolta(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)

--- a/tests/test_minolta.py
+++ b/tests/test_minolta.py
@@ -1,13 +1,15 @@
 import pytest
 
-from hrl.photometer.minolta import Minolta
-
 pytestmark = [pytest.mark.photometer]
 
 
 def test_initialization():
+    from hrl.photometer.minolta import Minolta
+
     Minolta(dev="/dev/ttyUSB0")
 
 
 def test_read_luminance():
+    from hrl.photometer.minolta import Minolta
+
     Minolta(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)

--- a/tests/test_minolta.py
+++ b/tests/test_minolta.py
@@ -3,13 +3,13 @@ import pytest
 pytestmark = [pytest.mark.photometer]
 
 
-def test_initialization():
+def test_initialization(photometer_dev):
     from hrl.photometer.minolta import Minolta
 
-    Minolta(dev="/dev/ttyUSB0")
+    Minolta(dev=photometer_dev)
 
 
-def test_read_luminance():
+def test_read_luminance(photometer_dev):
     from hrl.photometer.minolta import Minolta
 
-    Minolta(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)
+    Minolta(dev=photometer_dev).readLuminance(n=5, slp=5)

--- a/tests/test_optical.py
+++ b/tests/test_optical.py
@@ -1,4 +1,8 @@
+import pytest
+
 from hrl.photometer.optical import OptiCAL
+
+pytestmark = [pytest.mark.photometer]
 
 
 def test_initialization():

--- a/tests/test_optical.py
+++ b/tests/test_optical.py
@@ -1,13 +1,15 @@
 import pytest
 
-from hrl.photometer.optical import OptiCAL
-
 pytestmark = [pytest.mark.photometer]
 
 
 def test_initialization():
+    from hrl.photometer.optical import OptiCAL
+
     OptiCAL(dev="/dev/ttyUSB0")
 
 
 def test_read_luminance():
+    from hrl.photometer.optical import OptiCAL
+
     OptiCAL(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)

--- a/tests/test_optical.py
+++ b/tests/test_optical.py
@@ -1,0 +1,9 @@
+from hrl.photometer.optical import OptiCAL
+
+
+def test_initialization():
+    OptiCAL(dev="/dev/ttyUSB0")
+
+
+def test_read_luminance():
+    OptiCAL(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)

--- a/tests/test_optical.py
+++ b/tests/test_optical.py
@@ -3,13 +3,13 @@ import pytest
 pytestmark = [pytest.mark.photometer]
 
 
-def test_initialization():
+def test_initialization(photometer_dev):
     from hrl.photometer.optical import OptiCAL
 
-    OptiCAL(dev="/dev/ttyUSB0")
+    OptiCAL(dev=photometer_dev)
 
 
-def test_read_luminance():
+def test_read_luminance(photometer_dev):
     from hrl.photometer.optical import OptiCAL
 
-    OptiCAL(dev="/dev/ttyUSB0").readLuminance(n=5, slp=5)
+    OptiCAL(dev=photometer_dev).readLuminance(n=5, slp=5)


### PR DESCRIPTION
Introduces pytest tests for Minolta and OptiCAL photometers. These tests can be skipped by running:
```
pytest -m "not photometer"
```
These are thus also not run (headless) CI.

These test whether we can connect to a photometer device, and whether we can read a luminance value.

This PR also *removes* the old OptiCAL test from the `hrl-util`. I think it makes more sense to keep all the tests together as pytests, where we also have the (device specific) graphics tests, interactive tests, etc.
This makes the `hrl-util` one step cleaner, so that we can focus it on monitor calibration in various forms.