### PR TITLE
Factory functions for device initialization

### DIFF
--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -1,31 +1,9 @@
 """HRL Graphics module - display device interfaces."""
 
-from .datapixx import DATAPixx
-from .gpu import GPU_RGB, GPU_grey
-from .graphics import Graphics, Graphics_grey, Graphics_RGB
-from .texture import Texture
-from .viewpixx import VIEWPixx_grey, VIEWPixx_RGB
-
 __all__ = [
-    "Graphics",
-    "Graphics_grey",
-    "Graphics_RGB",
-    "GPU_grey",
-    "GPU_RGB",
-    "DATAPixx",
-    "VIEWPixx_grey",
-    "VIEWPixx_RGB",
+    "new_graphics",
     "Texture",
 ]
-
-
-ALIAS_MAP = {
-    "GPU_grey": ["gpu", "gpu_grey", "grey", "gray", "gray8"],
-    "GPU_RGB": ["gpu_RGB", "RGB"],
-    "VIEWPixx_grey": ["viewpixx", "viewpixx_grey", "viewpixx_gray", "viewpixx_gray8"],
-    "VIEWPixx_RGB": ["viewpixx_RGB", "viewpixx_color", "viewpixx_colour"],
-    "DataPixx": ["datapixx", "datapixx_grey", "datapixx_gray", "datapixx_gray8"],
-}
 
 
 def new_graphics(
@@ -46,7 +24,11 @@ def new_graphics(
     Parameters
     ----------
     graphics_alias : str
-        alias for the desired graphics device. Valid options are defined in ALIAS_MAP.
+        alias for the desired graphics device. Valid options include:
+        'gpu', 'gpu_grey', 'grey', 'gray', 'gray8', 'gpu_RGB', 'RGB',
+        'viewpixx', 'viewpixx_grey', 'viewpixx_gray', 'viewpixx_gray8',
+        'viewpixx_RGB', 'viewpixx_color', 'viewpixx_colour',
+        'datapixx', 'datapixx_grey', 'datapixx_gray', 'datapixx_gray8'.
     width : int
         width of the screen in pixels.
     height : int
@@ -80,21 +62,25 @@ def new_graphics(
     ------
     ValueError
         if the provided graphics_alias does not match any known device aliases
-        (see ALIAS_MAP for valid options)
     """
-    if graphics_alias in ALIAS_MAP["GPU_grey"]:
-        graphics_class = GPU_grey
-    elif graphics_alias in ALIAS_MAP["GPU_RGB"]:
-        graphics_class = GPU_grey
-    elif graphics_alias in ALIAS_MAP["DataPixx"]:
-        graphics_class = GPU_grey
-    elif graphics_alias in ALIAS_MAP["VIEWPixx_grey"]:
-        graphics_class = GPU_grey
-    elif graphics_alias in ALIAS_MAP["VIEWPixx_RGB"]:
-        graphics_class = GPU_grey
+    # Lazy import the graphics class based on alias
+    if graphics_alias in ["gpu", "gpu_grey", "grey", "gray", "gray8"]:
+        from .gpu import GPU_grey as graphics_class
+    elif graphics_alias in ["gpu_RGB", "RGB"]:
+        from .gpu import GPU_RGB as graphics_class
+    elif graphics_alias in ["viewpixx", "viewpixx_grey", "viewpixx_gray", "viewpixx_gray8"]:
+        from .viewpixx import VIEWPixx_grey as graphics_class
+    elif graphics_alias in ["viewpixx_RGB", "viewpixx_color", "viewpixx_colour"]:
+        from .viewpixx import VIEWPixx_RGB as graphics_class
+    elif graphics_alias in ["datapixx", "datapixx_grey", "datapixx_gray", "datapixx_gray8"]:
+        from .datapixx import DATAPixx as graphics_class
     else:
         raise ValueError(
-            f"Unknown graphics device '{graphics_alias}'. Valid options are: {ALIAS_MAP.items()}"
+            f"Unknown graphics device '{graphics_alias}'. Valid options are: "
+            f"'gpu', 'gpu_grey', 'grey', 'gray', 'gray8', 'gpu_RGB', 'RGB', "
+            f"'viewpixx', 'viewpixx_grey', 'viewpixx_gray', 'viewpixx_gray8', "
+            f"'viewpixx_RGB', 'viewpixx_color', 'viewpixx_colour', "
+            f"'datapixx', 'datapixx_grey', 'datapixx_gray', 'datapixx_gray8'"
         )
 
     return graphics_class(

--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -17,3 +17,92 @@ __all__ = [
     "VIEWPixx_RGB",
     "Texture",
 ]
+
+
+ALIAS_MAP = {
+    "GPU_grey": ["gpu", "gpu_grey", "grey", "gray", "gray8"],
+    "GPU_RGB": ["gpu_RGB", "RGB"],
+    "VIEWPixx_grey": ["viewpixx", "viewpixx_grey", "viewpixx_gray", "viewpixx_gray8"],
+    "VIEWPixx_RGB": ["viewpixx_RGB", "viewpixx_color", "viewpixx_colour"],
+    "DataPixx": ["datapixx", "datapixx_grey", "datapixx_gray", "datapixx_gray8"],
+}
+
+
+def new_graphics(
+    graphics_alias,
+    width,
+    height,
+    background=0.5,
+    fullscreen=False,
+    double_buffer=True,
+    lut=None,
+    mouse=False,
+):
+    """Factory function to create appropriate Graphics subclass based on configuration.
+
+    This function can be extended to read from a configuration file or environment
+    variables to determine which graphics device to instantiate (e.g., GPU, DataPixx, ViewPixx).
+
+    Parameters
+    ----------
+    graphics_alias : str
+        alias for the desired graphics device. Valid options are defined in ALIAS_MAP.
+    width : int
+        width of the screen in pixels.
+    height : int
+        height of the screen in pixels.
+    background : float or tuple, optional
+        background intensity value (0.0, 1.0), by default 0.5.
+        For grayscale devices, this is a gray level;
+        for color devices, can specify an RGB triplet.
+    fullscreen : bool, optional
+        run in Fullscreen, by default False
+    double_buffer : bool, optional
+        use double buffering, by default True.
+    lut : Path or str, optional
+        Path to Look-up Table, by default None.
+    mouse : bool, optional
+        enable mouse cursor, by default False.
+    screen : int or str, optional
+        which monitor to use, by default None (use the environment).
+        Given as an integer (e.g., 0, 1),
+        or as a string containing the X11 screen specification string (e.g., ":0.1" or ":1").
+    width_offset : int, optional
+        horizontal offset of the window, in pixels, by default 0.
+        Useful for setups with multiple monitors but a single Xscreen session.
+
+    Returns
+    -------
+    Graphics
+        an instance of a concrete Graphics subclass appropriate for the specified hardware setup
+
+    Raises
+    ------
+    ValueError
+        if the provided graphics_alias does not match any known device aliases
+        (see ALIAS_MAP for valid options)
+    """
+    if graphics_alias in ALIAS_MAP["GPU_grey"]:
+        graphics_class = GPU_grey
+    elif graphics_alias in ALIAS_MAP["GPU_RGB"]:
+        graphics_class = GPU_grey
+    elif graphics_alias in ALIAS_MAP["DataPixx"]:
+        graphics_class = GPU_grey
+    elif graphics_alias in ALIAS_MAP["VIEWPixx_grey"]:
+        graphics_class = GPU_grey
+    elif graphics_alias in ALIAS_MAP["VIEWPixx_RGB"]:
+        graphics_class = GPU_grey
+    else:
+        raise ValueError(
+            f"Unknown graphics device '{graphics_alias}'. Valid options are: {ALIAS_MAP.items()}"
+        )
+
+    return graphics_class(
+        width=width,
+        height=height,
+        background=background,
+        fullscreen=fullscreen,
+        double_buffer=double_buffer,
+        lut=lut,
+        mouse=mouse,
+    )

--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -1,5 +1,6 @@
 """HRL Graphics module - display device interfaces."""
 
+import importlib
 import os
 import platform
 
@@ -7,6 +8,29 @@ __all__ = [
     "new_graphics",
     "Texture",
 ]
+
+GRAPHICS_GREY_ALIASES = {
+    "gpu_grey": "gpu.GPU_grey",
+    "grey": "gpu.GPU_grey",
+    "gray": "gpu.GPU_grey",
+    "gray8": "gpu.GPU_grey",
+    "viewpixx": "viewpixx.VIEWPixx_grey",
+    "viewpixx_grey": "viewpixx.VIEWPixx_grey",
+    "viewpixx_gray": "viewpixx.VIEWPixx_grey",
+    "viewpixx_gray8": "viewpixx.VIEWPixx_grey",
+    "datapixx": "datapixx.DATAPixx",
+    "datapixx_grey": "datapixx.DATAPixx",
+    "datapixx_gray": "datapixx.DATAPixx",
+    "datapixx_gray8": "datapixx.DATAPixx",
+}
+GRAPHICS_RGB_ALIASES = {
+    "gpu_RGB": "gpu.GPU_RGB",
+    "RGB": "gpu.GPU_RGB",
+    "viewpixx_RGB": "viewpixx.VIEWPixx_RGB",
+    "viewpixx_color": "viewpixx.VIEWPixx_RGB",
+    "viewpixx_colour": "viewpixx.VIEWPixx_RGB",
+}
+GRAPHICS_ALIASES = {**GRAPHICS_GREY_ALIASES, **GRAPHICS_RGB_ALIASES}
 
 
 def new_graphics(
@@ -69,23 +93,14 @@ def new_graphics(
         if the provided graphics_alias does not match any known device aliases
     """
     # Lazy import the graphics class based on alias
-    if graphics_alias in ["gpu", "gpu_grey", "grey", "gray", "gray8"]:
-        from .gpu import GPU_grey as graphics_class
-    elif graphics_alias in ["gpu_RGB", "RGB"]:
-        from .gpu import GPU_RGB as graphics_class
-    elif graphics_alias in ["viewpixx", "viewpixx_grey", "viewpixx_gray", "viewpixx_gray8"]:
-        from .viewpixx import VIEWPixx_grey as graphics_class
-    elif graphics_alias in ["viewpixx_RGB", "viewpixx_color", "viewpixx_colour"]:
-        from .viewpixx import VIEWPixx_RGB as graphics_class
-    elif graphics_alias in ["datapixx", "datapixx_grey", "datapixx_gray", "datapixx_gray8"]:
-        from .datapixx import DATAPixx as graphics_class
+    if graphics_alias in GRAPHICS_ALIASES:
+        module_name, class_name = GRAPHICS_ALIASES[graphics_alias].rsplit(".", 1)
+        module = importlib.import_module(f".{module_name}", package=__name__)
+        graphics_class = getattr(module, class_name)
     else:
         raise ValueError(
             f"Unknown graphics device '{graphics_alias}'. Valid options are: "
-            f"'gpu', 'gpu_grey', 'grey', 'gray', 'gray8', 'gpu_RGB', 'RGB', "
-            f"'viewpixx', 'viewpixx_grey', 'viewpixx_gray', 'viewpixx_gray8', "
-            f"'viewpixx_RGB', 'viewpixx_color', 'viewpixx_colour', "
-            f"'datapixx', 'datapixx_grey', 'datapixx_gray', 'datapixx_gray8'"
+            f"{', '.join(list(GRAPHICS_GREY_ALIASES.keys()) + list(GRAPHICS_RGB_ALIASES.keys()))}"
         )
 
     # Run screen setup for multiple monitor support

--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -1,5 +1,8 @@
 """HRL Graphics module - display device interfaces."""
 
+import os
+import platform
+
 __all__ = [
     "new_graphics",
     "Texture",
@@ -15,6 +18,8 @@ def new_graphics(
     double_buffer=True,
     lut=None,
     mouse=False,
+    screen=None,
+    width_offset=0,
 ):
     """Factory function to create appropriate Graphics subclass based on configuration.
 
@@ -83,12 +88,40 @@ def new_graphics(
             f"'datapixx', 'datapixx_grey', 'datapixx_gray', 'datapixx_gray8'"
         )
 
+    # Run screen setup for multiple monitor support
+    screen_setup(screen=screen, window_width_offset=width_offset)
+
     return graphics_class(
         width=width,
         height=height,
         background=background,
-        fullscreen=fullscreen,
+        fullscreen=False,
         double_buffer=double_buffer,
         lut=lut,
         mouse=mouse,
     )
+
+
+def screen_setup(screen, window_width_offset):
+    ####### Setting up on which monitor to use
+    # In older systems or systems with separate Xscreens, the naming is still :0.0 or :0.1.
+    # For systems with only one screen, it is :1.
+    if platform.system() == "Linux":
+        print(f"Default screen number used by the OS: {os.environ['DISPLAY']}")
+
+        if screen is not None:
+            # legacy option for older configs or separate Xscreens
+            if os.environ["DISPLAY"] == ":0":
+                os.environ["DISPLAY"] = ":0." + str(screen)
+            else:
+                if isinstance(screen, str):
+                    os.environ["DISPLAY"] = screen
+                elif isinstance(screen, int):
+                    os.environ["DISPLAY"] = ":" + str(screen)
+
+            print(f"Display number changed to: {os.environ['DISPLAY']}")
+
+        ## 11. Aug 2021
+        # we add a wdth_offset to be able to run HRL in setups with a
+        # single Xscreen but multiple monitors (a config with Xinerama enabled)
+        os.environ["SDL_VIDEO_WINDOW_POS"] = f"{window_width_offset},0"

--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -6,10 +6,13 @@ import platform
 
 __all__ = [
     "new_graphics",
+    "ALIASES",
+    "GREY_ALIASES",
+    "RGB_ALIASES",
     "Texture",
 ]
 
-GRAPHICS_GREY_ALIASES = {
+GREY_ALIASES = {
     "gpu_grey": "gpu.GPU_grey",
     "grey": "gpu.GPU_grey",
     "gray": "gpu.GPU_grey",
@@ -23,14 +26,14 @@ GRAPHICS_GREY_ALIASES = {
     "datapixx_gray": "datapixx.DATAPixx",
     "datapixx_gray8": "datapixx.DATAPixx",
 }
-GRAPHICS_RGB_ALIASES = {
+RGB_ALIASES = {
     "gpu_RGB": "gpu.GPU_RGB",
     "RGB": "gpu.GPU_RGB",
     "viewpixx_RGB": "viewpixx.VIEWPixx_RGB",
     "viewpixx_color": "viewpixx.VIEWPixx_RGB",
     "viewpixx_colour": "viewpixx.VIEWPixx_RGB",
 }
-GRAPHICS_ALIASES = {**GRAPHICS_GREY_ALIASES, **GRAPHICS_RGB_ALIASES}
+ALIASES = {**GREY_ALIASES, **RGB_ALIASES}
 
 
 def new_graphics(
@@ -45,7 +48,7 @@ def new_graphics(
     screen=None,
     width_offset=0,
 ):
-    """Factory function to create appropriate Graphics subclass based on configuration.
+    """Factory function to create appropriate Graphics subclass based on provided alias.
 
     This function can be extended to read from a configuration file or environment
     variables to determine which graphics device to instantiate (e.g., GPU, DataPixx, ViewPixx).
@@ -53,11 +56,8 @@ def new_graphics(
     Parameters
     ----------
     graphics_alias : str
-        alias for the desired graphics device. Valid options include:
-        'gpu', 'gpu_grey', 'grey', 'gray', 'gray8', 'gpu_RGB', 'RGB',
-        'viewpixx', 'viewpixx_grey', 'viewpixx_gray', 'viewpixx_gray8',
-        'viewpixx_RGB', 'viewpixx_color', 'viewpixx_colour',
-        'datapixx', 'datapixx_grey', 'datapixx_gray', 'datapixx_gray8'.
+        alias for the desired graphics device. Valid options can be found in the
+        hrl.graphics.ALIASES.keys().
     width : int
         width of the screen in pixels.
     height : int
@@ -85,22 +85,22 @@ def new_graphics(
     Returns
     -------
     Graphics
-        an instance of a concrete Graphics subclass appropriate for the specified hardware setup
+        an instance of a concrete Graphics subclass corresponding to the provided alias
 
     Raises
     ------
     ValueError
-        if the provided graphics_alias does not match any known device aliases
+        if the provided graphics_alias does not match any known device
     """
     # Lazy import the graphics class based on alias
-    if graphics_alias in GRAPHICS_ALIASES:
-        module_name, class_name = GRAPHICS_ALIASES[graphics_alias].rsplit(".", 1)
+    if graphics_alias in ALIASES:
+        module_name, class_name = ALIASES[graphics_alias].rsplit(".", 1)
         module = importlib.import_module(f".{module_name}", package=__name__)
         graphics_class = getattr(module, class_name)
     else:
         raise ValueError(
             f"Unknown graphics device '{graphics_alias}'. Valid options are: "
-            f"{', '.join(list(GRAPHICS_GREY_ALIASES.keys()) + list(GRAPHICS_RGB_ALIASES.keys()))}"
+            f"{', '.join(list(ALIASES.keys()))}"
         )
 
     # Run screen setup for multiple monitor support

--- a/hrl/graphics/__init__.py
+++ b/hrl/graphics/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
 
 GREY_ALIASES = {
     "gpu_grey": "gpu.GPU_grey",
+    "gpu": "gpu.GPU_grey",
     "grey": "gpu.GPU_grey",
     "gray": "gpu.GPU_grey",
     "gray8": "gpu.GPU_grey",

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -7,6 +7,7 @@ import numpy as np
 import pygame
 
 import hrl.graphics
+import hrl.inputs
 
 ### HRL Class ###
 
@@ -103,21 +104,11 @@ class HRL:
             width_offset=wdth_offset,
         )
 
-        ## Load Input Device ##
-
-        if inputs == "keyboard":
-            from .inputs.keyboard import Keyboard
-
-            self.inputs = Keyboard()
-
-        elif inputs == "responsepixx":
-            from .inputs.responsepixx import RESPONSEPixx
-
-            # Assume hardware connection already established by graphics
-            self.inputs = RESPONSEPixx(self.graphics.device)
-
-        else:
-            self.inputs = None
+        ## Setup Input Device ##
+        self.inputs = hrl.inputs.new_input(
+            input_alias=inputs,
+            device=self.graphics.device,
+        )
 
         ## Load Photometer ##
 

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -8,6 +8,7 @@ import pygame
 
 import hrl.graphics
 import hrl.inputs
+import hrl.photometer
 
 ### HRL Class ###
 
@@ -110,18 +111,13 @@ class HRL:
             device=self.graphics.device,
         )
 
-        ## Load Photometer ##
-
-        if photometer == "optical":
-            from .photometer.optical import OptiCAL
-            self.photometer = OptiCAL("/dev/ttyUSB0", timeout=10)
-            
-        elif photometer == "minolta":
-            from .photometer.minolta import Minolta
-            self.photometer = Minolta("/dev/ttyUSB0")
-
-        else:
-            self.photometer = None
+        ## Setup photometer ##
+        if photometer is not None:
+            self.photometer = hrl.photometer.new_photometer(
+                photometer_alias=photometer,
+                device="/dev/ttyUSB0",
+                timeout=10,
+            )
 
         ## Results file ##
         self._rfl = None

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -2,7 +2,6 @@
 
 import csv
 import os
-import platform
 
 import numpy as np
 import pygame
@@ -90,36 +89,7 @@ class HRL:
         experiment.
         """
 
-        ####### Setting up on which monitor to use
-        # In older systems or systems with separate Xscreens, the naming is still :0.0 or :0.1.
-        # For systems with only one screen, it is :1.
-        if platform.system() == "Linux":
-            print("default screen number used by the OS: %s" % os.environ["DISPLAY"])
-
-            if scrn!=None:
-                # legacy option for older configs or separate Xscreens  
-                if (os.environ["DISPLAY"] == ":0"): 
-                    os.environ["DISPLAY"] = ":0." + str(scrn)
-                else:
-                    if isinstance(scrn, str):
-                        os.environ["DISPLAY"] = scrn
-                    elif isinstance(scrn, int):
-                        os.environ["DISPLAY"] = ":" + str(scrn)
-
-                print("display number changed to: %s" % os.environ["DISPLAY"])
-
-            ## 11. Aug 2021
-            # we add a wdth_offset to be able to run HRL in setups with a
-            # single Xscreen but multiple monitors (a config with Xinerama enabled)
-            os.environ["SDL_VIDEO_WINDOW_POS"] = "%d,0" % wdth_offset
-
-        # we force not fullscreen, even in experimental computer,
-        # because in later versions of pygame
-        # fullscreen on a second screen gives very weird behavior on
-        # recording of keyboard events, effectively hanging the computer.
-        fs = False
-
-        ## Load Graphics Device ##
+        ## Setup screen and graphics ##
         self.graphics = hrl.graphics.new_graphics(
             graphics_alias=graphics.lower(),
             width=wdth,
@@ -129,6 +99,8 @@ class HRL:
             double_buffer=db,
             lut=lut,
             mouse=mouse,
+            screen=scrn,
+            width_offset=wdth_offset,
         )
 
         ## Load Input Device ##

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -7,6 +7,8 @@ import platform
 import numpy as np
 import pygame
 
+import hrl.graphics
+
 ### HRL Class ###
 
 
@@ -118,71 +120,16 @@ class HRL:
         fs = False
 
         ## Load Graphics Device ##
-        if graphics.lower() in ("gpu", "gpu_grey", "grey", "gray", "gray8"):
-            from .graphics.gpu import GPU_grey
-
-            self.graphics = GPU_grey(
-                width=wdth,
-                height=hght,
-                background=bg,
-                fullscreen=fs,
-                double_buffer=db,
-                lut=lut,
-                mouse=mouse,
-            )
-        elif graphics.lower() in ("gpu_rgb", "rgb"):
-            from .graphics.gpu import GPU_RGB
-
-            self.graphics = GPU_RGB(
-                width=wdth,
-                height=hght,
-                background=[bg, bg, bg],
-                fullscreen=fs,
-                double_buffer=db,
-                lut=lut,
-                mouse=mouse,
-            )
-
-        elif graphics.lower() == "datapixx":
-            from .graphics.datapixx import DATAPixx
-
-            self.graphics = DATAPixx(
-                width=wdth,
-                height=hght,
-                background=bg,
-                fullscreen=fs,
-                double_buffer=db,
-                lut=lut,
-                mouse=mouse,
-            )
-        elif graphics.lower() in ("viewpixx", "viewpixx_grey", "viewpixx_gray", "viewpixx_gray8"):
-            from .graphics.viewpixx import VIEWPixx_grey
-
-            self.graphics = VIEWPixx_grey(
-                width=wdth,
-                height=hght,
-                background=bg,
-                fullscreen=fs,
-                double_buffer=db,
-                lut=lut,
-                mouse=mouse,
-            )
-
-        elif graphics.lower() in ("viewpixx_rgb", "viewpixx_color", "viewpixx_colour"):
-            from .graphics.viewpixx import VIEWPixx_RGB
-
-            self.graphics = VIEWPixx_RGB(
-                width=wdth,
-                height=hght,
-                background=[bg, bg, bg],
-                fullscreen=fs,
-                double_buffer=db,
-                lut=lut,
-                mouse=mouse,
-            )
-
-        else:
-            self.graphics = None
+        self.graphics = hrl.graphics.new_graphics(
+            graphics_alias=graphics.lower(),
+            width=wdth,
+            height=hght,
+            background=bg,
+            fullscreen=fs,
+            double_buffer=db,
+            lut=lut,
+            mouse=mouse,
+        )
 
         ## Load Input Device ##
 

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -53,42 +53,56 @@ class HRL:
         lut=None,
         mouse=False,
     ):
-        """
-        Initialize an HRL object.
+        """Initialize an HRL object.
 
         Parameters
         ----------
-
-        graphics : The graphics device to use. Available: 'gpu','datapixx'
-            (to be used with DataPixx 1) or 'viewpixx' (for ViewPixx 3D).
-            Default: 'gpu'
-        inputs : The input device to use. Available: 'keyboard', 'responsepixx'.
-            Default: 'keyboard'
-        photometer : The graphics device to use. Available: 'optical', 'minolta', None.
-            Default: None
-        wdth : The desired width of the screen. Default: 1024
-        hght : The desired height of the screen. Default: 768
-        bg : The background luminance on a scale from 0 to 1. Default: 0.0
-        fs : Whether or not to run in Fullscreen. Default: False
-        wdth_offset: The desired horizontal offset of the window. Useful for setups
-              with multiple monitors but a single Xscreen session. Default: 0
-        db : Whether or not to use double buffering. Default: True
-        scrn: Which monitor to use, given as an integer (e.g. 0, 1), or as a string containing the 
-              X11 screen specification string (e.g. ":0.1" or ":1"). 
-              Default: None (uses the default settings) 
-        dfl : The read location of the design matrix. Default: None
-        rfl : The write location of the result matrix. Default: None
-        rhds : A list of the string names of the headers for the Result
-            Matrix. The string names should be without spaces, e.g.
-            'InputLuminance'. If rfl != None, rhds must be provided.
-            Default: None
-        lut : The lookup table. Default: None
-        mouse: enables or disables the mouse cursor. Default: False
+        graphics : str
+            alias for the desired graphics device, by default "gpu".
+            Valid options are defined in hrl.graphics.ALIAS_MAP.
+        inputs : str
+            alias for the desired input device, by default "keyboard".
+        photometer : str or None
+            alias for the desired photometer device, by default None.
+        wdth : int
+            width of the screen in pixels, by default 1024.
+        hght : int
+            height of the screen in pixels, by default 768.
+        bg : float or tuple, optional
+            background intensity value (0.0, 1.0), by default 0.0.
+            For grayscale devices, this is a gray level;
+            for color devices, can specify an RGB triplet.
+        fs : bool, optional
+            run in Fullscreen, currently fixed to False -- because in later versions of pygame
+            fullscreen on a second screen gives very weird behavior on recording of keyboard events,
+            effectively hanging the computer.
+        wdth_offset: int, optional
+            horizontal offset of the window, in pixels, by default 0.
+            Useful for setups with multiple monitors but a single Xscreen session.
+        db : bool, optional
+            use double buffering, by default True.
+        scrn : int or str, optional
+            which monitor to use, by default None (use the environment).
+            Given as an integer (e.g., 0, 1),
+            or as a string containing the X11 screen specification string (e.g., ":0.1" or ":1").
+        dfl : Path or str or None, optional
+            path to design file, by default None.
+        rfl : Path or str or None, optional
+            path to results file, by default None.
+        rhds : List(str) or None, optional
+            headers for the Result Matrix, by default None.
+            The string names should be without spaces, e.g. 'InputLuminance'.
+            If rfl != None, rhds must be provided.
+        lut : Path or str or None, optional
+            Path to Look-up Table, by default None.
+        mouse: bool, optional
+            enables or disables the mouse cursor, by default False.
 
         Returns
         -------
-        hrl instance. Comes with a number of methods required to run an
-        experiment.
+        HRL
+            an initialized hrl instance.
+            Comes with a number of methods required to run an experiment.
         """
 
         ## Setup screen and graphics ##

--- a/hrl/inputs/__init__.py
+++ b/hrl/inputs/__init__.py
@@ -1,0 +1,28 @@
+def new_input(input_alias, device=None):
+    """Factory function to create appropriate Input subclass based on configuration.
+
+    This function can be extended to read from a configuration file or environment
+    variables to determine which input device to instantiate (e.g., Keyboard, RESPONSEPixx).
+
+    Parameters
+    ----------
+    input_alias : str
+        alias for the desired input device. Valid options: 'keyboard', 'responsepixx'.
+
+    Returns
+    -------
+    Input
+        an instance of the appropriate Input subclass.
+    """
+    if input_alias == "keyboard":
+        from .keyboard import Keyboard as input_class
+    elif input_alias == "responsepixx":
+        from .responsepixx import RESPONSEPixx as input_class
+    else:
+        raise ValueError(
+            f"Unknown input device '{input_alias}'. Valid options are: 'keyboard', 'responsepixx'"
+        )
+
+    input_device = input_class()
+    input_device.device = device
+    return input_device

--- a/hrl/inputs/__init__.py
+++ b/hrl/inputs/__init__.py
@@ -1,26 +1,45 @@
-def new_input(input_alias, device=None):
-    """Factory function to create appropriate Input subclass based on configuration.
+import importlib
 
-    This function can be extended to read from a configuration file or environment
-    variables to determine which input device to instantiate (e.g., Keyboard, RESPONSEPixx).
+__all__ = [
+    "new_input",
+    "ALIASES",
+]
+
+ALIASES = {
+    "keyboard": "keyboard.Keyboard",
+    "responsepixx": "responsepixx.RESPONSEPixx",
+}
+
+
+def new_input(input_alias, device=None):
+    """Factory function to create appropriate Input subclass based on provided alias.
 
     Parameters
     ----------
     input_alias : str
-        alias for the desired input device. Valid options: 'keyboard', 'responsepixx'.
+        alias for the desired input device. Valid options can be found in the
+        hrl.inputs.ALIASES.keys().
 
     Returns
     -------
     Input
-        an instance of the appropriate Input subclass.
+        an instance of the Input subclass corresponding to the provided alias
+
+    Raises
+    ------
+    ValueError
+        if the provided input_alias does not match any known input device
+
     """
-    if input_alias == "keyboard":
-        from .keyboard import Keyboard as input_class
-    elif input_alias == "responsepixx":
-        from .responsepixx import RESPONSEPixx as input_class
+    # Lazy import the input class based on alias
+    if input_alias in ALIASES:
+        module_name, class_name = ALIASES[input_alias].rsplit(".", 1)
+        module = importlib.import_module(f".{module_name}", package=__name__)
+        input_class = getattr(module, class_name)
     else:
         raise ValueError(
-            f"Unknown input device '{input_alias}'. Valid options are: 'keyboard', 'responsepixx'"
+            f"Unknown input device '{input_alias}'. Valid options are: "
+            f"{', '.join(list(ALIASES.keys()))}"
         )
 
     input_device = input_class()

--- a/hrl/inputs/inputs.py
+++ b/hrl/inputs/inputs.py
@@ -22,6 +22,8 @@ class Input(ABC):
     a clear explanation of the keymap if it deviates from this typical set.
     """
 
+    device = None
+
     @abstractmethod
     def readButton(self, btns, to):
         """

--- a/hrl/inputs/responsepixx.py
+++ b/hrl/inputs/responsepixx.py
@@ -17,10 +17,6 @@ class RESPONSEPixx(Input):
     implementation.
     """
 
-    def __init__(self, device):
-        super(RESPONSEPixx, self).__init__()
-        self.device = device
-
     ## new function in HRL3. waitButton() function implemented in python
     ## in previous version of HRL waitButton() was a function of the
     ## datapixx.so python wrapper

--- a/hrl/photometer/__init__.py
+++ b/hrl/photometer/__init__.py
@@ -1,0 +1,33 @@
+def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=10):
+    """Factory function to create a new photometer instance based on the provided name.
+
+    Parameters
+    ----------
+    photometer_alias : str
+        name of the photometer to create. Valid options: 'optical', 'minolta'.
+    device : str, optional
+        device path to the photometer, by default "/dev/ttyUSB0".
+    timeout : int, optional
+        timeout in seconds for communication with the photometer, by default 10.
+
+    Returns
+    -------
+    Photometer
+        instance of the photometer corresponding to the provided alias.
+
+    Raises
+    ------
+    ValueError
+        If the provided photometer_alias does not match any known photometer.
+
+    """
+    if photometer_alias == "optical":
+        from .optical import OptiCAL as photometer_class
+    elif photometer_alias == "minolta":
+        from .minolta import Minolta as photometer_class
+    else:
+        raise ValueError(
+            f"Unknown photometer: {photometer_alias}. Valid options are: 'optical', 'minolta'"
+        )
+
+    return photometer_class(device, timeout=timeout)

--- a/hrl/photometer/__init__.py
+++ b/hrl/photometer/__init__.py
@@ -1,10 +1,24 @@
+import importlib
+
+__all__ = [
+    "new_photometer",
+    "ALIASES",
+]
+
+ALIASES = {
+    "optical": "optical.OptiCAL",
+    "minolta": "minolta.Minolta",
+}
+
+
 def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=10):
     """Factory function to create a new photometer instance based on the provided name.
 
     Parameters
     ----------
     photometer_alias : str
-        name of the photometer to create. Valid options: 'optical', 'minolta'.
+        alias for the desired photometer. Valid options can be found in the
+        hrl.photometer.ALIASES.keys().
     device : str, optional
         device path to the photometer, by default "/dev/ttyUSB0".
     timeout : int, optional
@@ -13,21 +27,23 @@ def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=10):
     Returns
     -------
     Photometer
-        instance of the photometer corresponding to the provided alias.
+        instance of the photometer subclass corresponding to the provided alias
 
     Raises
     ------
     ValueError
-        If the provided photometer_alias does not match any known photometer.
+        if the provided photometer_alias does not match any known photometer device
 
     """
-    if photometer_alias == "optical":
-        from .optical import OptiCAL as photometer_class
-    elif photometer_alias == "minolta":
-        from .minolta import Minolta as photometer_class
+    # Lazy import the photometer class based on alias
+    if photometer_alias in ALIASES:
+        module_name, class_name = ALIASES[photometer_alias].rsplit(".", 1)
+        module = importlib.import_module(f".{module_name}", package=__name__)
+        photometer_class = getattr(module, class_name)
     else:
         raise ValueError(
-            f"Unknown photometer: {photometer_alias}. Valid options are: 'optical', 'minolta'"
+            f"Unknown photometer device '{photometer_alias}'. Valid options are: "
+            f"{', '.join(list(ALIASES.keys()))}"
         )
 
     return photometer_class(device, timeout=timeout)

--- a/hrl/util/__init__.py
+++ b/hrl/util/__init__.py
@@ -1,7 +1,6 @@
 """HRL utility package for calibration and testing."""
 
 import argparse
-import inspect
 
 import hrl.graphics
 
@@ -10,12 +9,7 @@ graphics_arggroup = graphics_argparser.add_argument_group("Graphics settings")
 graphics_arggroup.add_argument(
     "-gr",
     "--graphics",
-    choices=[
-        alias
-        for alias in hrl.graphics.__all__
-        if not inspect.isabstract(device := getattr(hrl.graphics, alias))
-        and issubclass(device, hrl.graphics.Graphics_grey)
-    ],
+    choices=[hrl.graphics.GRAPHICS_GREY_ALIASES.keys()],
     default="datapixx",
     help="Graphics device (default: datapixx)",
 )

--- a/hrl/util/__init__.py
+++ b/hrl/util/__init__.py
@@ -9,7 +9,7 @@ graphics_arggroup = graphics_argparser.add_argument_group("Graphics settings")
 graphics_arggroup.add_argument(
     "-gr",
     "--graphics",
-    choices=[hrl.graphics.GRAPHICS_GREY_ALIASES.keys()],
+    choices=[hrl.graphics.GREY_ALIASES.keys()],
     default="datapixx",
     help="Graphics device (default: datapixx)",
 )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -57,7 +57,7 @@ def test_hrl_class():
     from hrl import HRL
 
     ihrl = HRL(
-        graphics="gpu_grey",
+        graphics="gpu",
         inputs="keyboard",
         wdth=200,
         hght=200,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -57,7 +57,7 @@ def test_hrl_class():
     from hrl import HRL
 
     ihrl = HRL(
-        graphics="gpu",
+        graphics="gpu_grey",
         inputs="keyboard",
         wdth=200,
         hght=200,


### PR DESCRIPTION
Adds factory functions to construct and setup graphics devices, input devices and photometers.
The public-facing API of the `HRL`-class does not change, making this change backwards compatible.

# Status quo, problem
Currently, the `HRL`-class contains a lot of logic for selecting and setting up the correct device. This works through 'device aliases'; strings such as `"gpu_grey"`, or `"keyboard"`. The user specifies a device alias, and the `HRL`-class constructs the corresponding object.

```py
        ## Load Graphics Device ##
        if graphics in ("gpu", "gpu_grey", "grey", "gray", "gray8"):
            from .graphics.gpu import GPU_grey

            self.graphics = GPU_grey(
                width=wdth,
                height=hght,
                background=bg,
                fullscreen=fs,
                double_buffer=db,
                lut=lut,
                mouse=mouse,
            )
        elif graphics in ("gpu_RGB", "RGB"):
            from .graphics.gpu import GPU_RGB

            self.graphics = GPU_RGB(
                ...
            )
        elif ....
```

This is an undesirable tight coupling between `HRL`-class and the devices. It requires a lot of this switching logic to be in the `HRL`-class. It also means that add more devices (or making changes to devices such as different parameters for initialization) requires updating of all this switching logic. In the end, it means that the `HRL`-object "needs to know" about the implementations of the graphics devices. This breaks the advantages of the Object-Oriented structure that we have.   ( #11 )

# Solution
This pull request moves all of that device intialization and switching logic, to dedicated factory functions, e.g., `hrl.graphics.new_graphics(...)`, `hrl.inputs.new_inputs(..)`. `HRL`-object then calls these factory functions. 
```py
        ## Setup screen and graphics ##
        self.graphics = hrl.graphics.new_graphics(
            graphics_alias=graphics,
            ...
        )
```
This moves all of the logic out of the `HRL`-class, decoupling it from the implementation classes. Thus, the `HRL`-class doesn't need to know _which_ graphics object was created -- it can just use it.


The one coupling that does remain in the `HRL`-class is that it takes the `.device` from the graphics object (which may hold the binding to a *Pixx device), as `HRL.device`, and then passes that to `new_input()` where it can be used to initialize a DATAPixx device. 
```py
    @property
    def device(self):
        return self.graphics.device if self.graphics else None
        
    ...
    
    ## Setup Input Device ##
    self.inputs = hrl.inputs.new_input(
        input_alias=inputs,
        device=self.graphics.device,
    )
```
So, HRL coordinates _between_ graphics, inputs, and photometer, rather than manage the individual devices.


## Implementation details
The submodule `graphics/__init__.py`, `inputs/__init__.py`, `photometer/__init__.py` define the factory functions, so that they can be called as `hrl.graphics.new_graphics()`. The factory functions take the same device alias strings that `HRL` previously did, and return an instantiated object of the correct subclass.
```py
my_graphics_obj = hrl.graphics.new_graphics('gpu_rgb', ...)
my_inputs_obj = hrl.inputs.new_input('keyboard', ...)
```
Inside these factory functions, the switching logic is set up so that potentially multiple aliases can refer to the same class to be constructed, e.g., `'gpu', 'gpu_grey', 'gpu_gray'` all refer to the same device class.

NOTE: one can still bypass the `new_graphics()` (and `HRL`-class) entirely, and just construct a device specific object directly:
```py
my_graphics_obj = hrl.graphics.gpu.GPU_grey(...)
````

The factory functions themselves *also* don't do any device specific initialization -- that's handled by the device-specific class. Thus, the `new_graphics()` does not need 'to know' about setting up, e.g., a ViewPixx vs. DataPixx. Only one device-specific module gets imported at a time, which also makes this more robust.



## Future proofing
Adding a new device-class thus is simpler: write the device-class as normal (inhereting from the correct super-class, e.g., `Graphics_grey` or `Graphics_GPU`). Then, add it with one or more aliases to `new_graphics()`:
```py
    ...
    # Lazy import the graphics class based on alias
    if graphics_alias in ["gpu", "gpu_grey", "grey", "gray", "gray8"]:
        from .gpu import GPU_grey as graphics_class
    elif graphics_alias in ["new_device"]:
        from .new_device import DEVICE_grey as graphics_class     
    ...
```

## Screen setup
Additionally, there is some necessary setting up of screens on multimonitor setups, via setting environment variables. This used to be done by the `HRL`-object as well. Now, it is in a `hrl.graphics.setup_screen()` function. This function can be called separately, but is also automatically called by `new_graphics()`.