### PR TITLE
Always output channels representation as (tuple of) arrays

### DIFF
--- a/hrl/graphics/datapixx.py
+++ b/hrl/graphics/datapixx.py
@@ -81,13 +81,13 @@ class DATAPixx(Graphics_grey):
 
         # Discretize to 16-bit integers, single channel
         arr = img * (2 ** (2 * self.bitdepth) - 1)
-        arr = np.uint32(arr)
+        arr = np.asarray(arr, dtype=np.uint32)
 
         # Convert to datapixx R-G concatenated format
         channels = (
             arr // (2**self.bitdepth),  # R channel (high byte)
             arr % (2**self.bitdepth),  # G channel (low byte)
-            0,  # B channel (not used)
+            np.zeros_like(arr),  # B channel (not used)
             2**self.bitdepth - 1,  # Alpha channel (max intensity)
         )
 

--- a/hrl/graphics/gpu.py
+++ b/hrl/graphics/gpu.py
@@ -43,7 +43,7 @@ class GPU_grey(Graphics_grey):
 
         # Discretize to 8-bit integers, single channel
         arr = img * (2**self.bitdepth - 1)
-        arr = np.uint32(arr)
+        arr = np.asarray(arr, dtype=np.uint32)
 
         # Duplicate to 4 channels, with max alpha
         channels = (
@@ -95,7 +95,7 @@ class GPU_RGB(Graphics_RGB):
 
         # Discretize to 8-bit integers, single channel
         arr = img * (2**self.bitdepth - 1)
-        arr = np.uint32(arr)
+        arr = np.asarray(arr, dtype=np.uint32)
 
         # Convert to 4 channels, with max alpha
         arr = (

--- a/hrl/graphics/viewpixx.py
+++ b/hrl/graphics/viewpixx.py
@@ -73,13 +73,13 @@ class VIEWPixx_grey(Graphics_grey):
 
         # Discretize to 16-bit integers, single channel
         arr = img * (2 ** (2 * self.bitdepth) - 1)
-        arr = np.uint32(arr)
+        arr = np.asarray(arr, dtype=np.uint32)
 
         # Convert to datapixx R-G concatenated format
         channels = (
             arr // (2**self.bitdepth),  # R channel (high byte)
             arr % (2**self.bitdepth),  # G channel (low byte)
-            0,  # B channel (not used)
+            np.zeros_like(arr),  # B channel (not used)
             2**self.bitdepth - 1,  # Alpha channel (max intensity)
         )
 
@@ -149,7 +149,7 @@ class VIEWPixx_RGB(Graphics_RGB):
 
         # Discretize to 8-bit integers, single channel
         arr = img * (2**self.bitdepth - 1)
-        arr = np.uint32(arr)
+        arr = np.asarray(arr, dtype=np.uint32)
 
         # Convert to 4 channels, with max alpha
         arr = (


### PR DESCRIPTION
On *Pixx devices in greyscale M16 mode, the B-channel is unused. This was hardcoded as just the integer `0`. That caused a problem (#33) in other places where we assumed it'd be a 2D array. Now, ensure that is also an array, with the same size as the input 'image'. This makes R, G, B channels always consistent in shape.