### PR TITLE
Colorimeter support: abstract class, MockColorimeter, i1Pro real colorimeter

### DIFF
--- a/examples/example_photometer_readout.py
+++ b/examples/example_photometer_readout.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import time
+
+import numpy as np
+from hrl import HRL
+from hrl.graphics import graphics
+
+WIDTH = 1024
+HEIGHT = 768
+
+# size of the rectangular patch
+sz = 0.5
+
+# size and position of rectangular patch
+pwdth, phght = WIDTH * sz, HEIGHT * sz
+ppos = (WIDTH - pwdth) / 2, (HEIGHT - phght) / 2
+    
+# number of intensities to be measured
+N = 10        
+            
+    
+def show_stim(hrl, intensity):
+    
+    # texture creation in buffer : stimulus
+    ptch = hrl.graphics.newTexture(np.array([[intensity]]))
+
+    # Show stimlus
+    ptch.draw(ppos, (pwdth, phght))
+
+    # flip everything
+    hrl.graphics.flip(clr=True)  # clr= True to clear buffer
+
+
+def run_block(hrl):
+    
+    # intensity vector
+    intensities = np.linspace(0, 1, N)
+    # randomize in place
+    np.random.shuffle(intensities)
+        
+    for intensity in intensities:
+        
+        # show rectangle
+        show_stim(hrl, intensity)
+        
+        # read photometer
+        lum = hrl.photometer.readLuminance()
+        #time.sleep(1)
+        #lum = 0.0
+        
+        print(f"Intensity {intensity:.2f} - Luminance {lum:.2f}")       
+      
+
+    print("Done")
+
+
+def run_experiment():
+
+    hrl = HRL(
+        graphics="gpu",
+        inputs="keyboard",
+        photometer='i1pro',
+        wdth=WIDTH,
+        hght=HEIGHT,
+        bg=0.5,
+        scrn=0,
+        lut=None,
+        db=True,
+        fs=False,
+    )
+
+    run_block(hrl)
+
+
+if __name__ == "__main__":
+    run_experiment()

--- a/hrl/cluts.py
+++ b/hrl/cluts.py
@@ -67,6 +67,111 @@ def gamma_correct_RGB(img, CLUT):
     return linearized_RGB
 
 
+def XYZ_from_CLUT(CLUT):
+    """Extract CIE 1931 XYZ color matching functions from a provided Color LUT.
+
+    Parameters
+    ----------
+    CLUT : Array[float]
+        Color Lookup Table with shape (N, 13), where
+        the first column is linear input intensities between [0.0, 1.0],
+        the next three columns are the corrected R, G, B values [0.0, 1.0],
+        and the last 3x3 columns are the CIE 1931 X, Y, Z values for each channel.
+
+    Returns
+    -------
+    Array[float]
+        color matrix (XYZ CIE 1931 from RGB) with shape (3, 3).
+    """
+    color_matrix = CLUT[-1, 4:13].reshape(3, 3)
+    dark_chromaticity = CLUT[0, 4:13].reshape((3, 3))
+
+    return color_matrix, dark_chromaticity
+
+
+def RGB_to_XYZ(img, color_matrix, dark_chromaticity=np.zeros((3, 3))):
+    """Convert RGB image to CIE 1931 XYZ color space using provided color matching functions.
+
+    Parameters
+    ----------
+    img : Array[float]
+        RGB image with values between [0.0, 1.0].
+        Shape: (H, W, 3).
+    color_matrix : Array[float]
+        color matrix (XYZ CIE 1931 from RGB) with shape (3, 3).
+    dark_chromaticity : Array[float], optional
+        dark chromaticity values for each channel with shape (3, 3), by default: None
+
+    Returns
+    -------
+    Array[float]
+        XYZ CIE 1931 image with shape (H, W, 3).
+    """
+    # Reshape image to (H*W, 3) for matrix multiplication
+    H, W, _ = img.shape
+    img_reshaped = img.reshape(-1, 3)
+
+    # Convert RGB to XYZ
+    XYZ_reshaped = img_reshaped @ color_matrix.T
+
+    # Add dark chromaticity
+    XYZ_reshaped += dark_chromaticity.sum(axis=0)
+
+    # Reshape back to (H, W, 3)
+    XYZ = XYZ_reshaped.reshape(H, W, 3)
+
+    return XYZ
+
+
+def invert_color_matrix(XYZ_from_RGB_matrix):
+    """Compute the inverse of a color matching matrix.
+
+    Parameters
+    ----------
+    XYZ_from_RGB_matrix : Array[float]
+        color matrix (XYZ CIE 1931 from RGB) with shape (3, 3).
+
+    Returns
+    -------
+    Array[float]
+        inverted color matrix (RGB from XYZ CIE 1931) with shape (3, 3).
+    """
+    return np.linalg.inv(XYZ_from_RGB_matrix)
+
+
+def XYZ_to_RGB(XYZ, inv_color_matrix, dark_chromaticity=np.zeros((3, 3))):
+    """Convert CIE 1931 XYZ image to RGB color space using provided inverse color matching functions.
+
+    Parameters
+    ----------
+    XYZ : Array[float]
+        XYZ CIE 1931 image with shape (H, W, 3).
+    inv_color_matrix : Array[float]
+        inverse color matrix (RGB from XYZ CIE 1931) with shape (3, 3).
+    dark_chromaticity : Array[float], optional
+        dark chromaticity values for each channel with shape (3, 3), by default: None
+
+    Returns
+    -------
+    Array[float]
+        RGB image with values between [0.0, 1.0] and shape (H, W, 3).
+    """
+    # Reshape image to (H*W, 3) for matrix multiplication
+    H, W, _ = XYZ.shape
+    XYZ_reshaped = XYZ.reshape(-1, 3)
+
+    # Subtract dark chromaticity
+    XYZ_reshaped -= dark_chromaticity.sum(axis=0)
+
+    # Convert XYZ to RGB
+    RGB_reshaped = XYZ_reshaped @ inv_color_matrix.T
+
+    # Reshape back to (H, W, 3)
+    RGB = RGB_reshaped.reshape(H, W, 3)
+
+    return RGB
+
+
 def create_clut(
     n=256,
     gamma=[1.0, 1.0, 1.0],

--- a/hrl/cluts.py
+++ b/hrl/cluts.py
@@ -1,0 +1,117 @@
+"""Color LookUp table (CLUT) utilities for gamma correction and color correction.
+
+HRL uses CLUTs to perform gamma correction on color images,
+mapping input intensities to linearized output intensities.
+This module provides functions to create and apply these CLUTs.
+
+The Color LUTs map input R, G, B intensities to linearized RGB values
+and provide a color transformation matrix for each intensity level.
+These CLUTs are structured as 2D NumPy arrays with thirteen columns:
+0: `intensity_in`: Input intensities (ranging between [0.0, 1.0])
+1-3: `R_out`, `G_out`, `B_out`: Gamma-corrected output RGB values
+4-12: 3x3 color transformation (RGB -> XYZ) matrix values, flattened row-wise:
+    [X_R, X_G, X_B, Y_R, Y_G, Y_B, Z_R, Z_G, Z_B]
+
+Generally, these CLUTs are created through measurement of a display
+and linearization of the resulting measurements.
+This can be done using the `hrl-util`, documented elsewhere.
+Here, we do provide a function to create parametric CLUTs
+based on standard gamma correction formulas
+-- this is useful for testing and simulation, but should not be used
+for real display characterization!
+
+
+Functions
+---------
+gamma_correct_RGB(img, CLUT)
+    Apply gamma correction to an RGB array using a provided color LUT.
+create_clut(n=256, gamma=[1.0, 1.0, 1.0], color_matrix=None, dark_chromaticity=None)
+    Create a parametric CLUT with gamma correction and color conversion.
+
+"""
+
+import numpy as np
+
+
+def gamma_correct_RGB(img, CLUT):
+    """Apply gamma correction to an RGB array using a provided color LUT.
+
+    Parameters
+    ----------
+    img : Array[float]
+        input RGB array with values between [0.0, 1.0].
+        Can be a single RGB triplet (shape: (1, 1, 3)) or an RGB image (shape: (H, W, 3)).
+    CLUT : Array[float]
+        Color LookUp Table with at least shape (N, 4), where the first column is
+        input intensities and the next three columns are the corrected R, G, B values.
+        Can have more columns, which will be ignored.
+
+    Returns
+    -------
+    Array[float]
+        gamma-corrected RGB array with the same shape as input.
+    """
+    # Apply interpolation per channel
+    linearized_RGB = np.array(
+        [
+            np.interp(img[..., channel], CLUT[:, 0], CLUT[:, channel + 1])
+            for channel in range(img.shape[-1])
+        ]
+    )
+
+    # Move channel axis from first to last position
+    # For (1, 1, 3) input: (3, 1, 1) -> (1, 1, 3)
+    # For (H, W, 3) input: (3, H, W) -> (H, W, 3)
+    linearized_RGB = np.moveaxis(linearized_RGB, 0, -1)
+
+    return linearized_RGB
+
+
+def create_clut(
+    n=256,
+    gamma=[1.0, 1.0, 1.0],
+    color_matrix=None,
+    dark_chromaticity=None,
+):
+    """Create a parametric CLUT with gamma correction and color conversion.
+
+    Parameters
+    ----------
+    n : int, optional
+        number of entries in the CLUT, by default 256.
+    gamma : [float, float, float] or float, optional
+        gamma exponents for R, G, B correction, by default [1.0, 1.0, 1.0].
+    color_matrix : Array, optional
+        3x3 color transformation matrix, by default identity (XYZ=RGB).
+    dark_chromaticity : Array, optional
+        3-element vector for dark state chromaticity (XYZ at black), by default zeros (no dark light).
+
+    Returns
+    -------
+    Array
+        with 13 columns [intensity_in, R_out, G_out, B_out, 9 matrix values]:
+            R_out, G_out, B_out = intensity_in^(1/gamma[i]) for each channel
+            First row's 3x3 matrix represents dark_chromaticity as the black point
+            Last row's 3x3 matrix is color_matrix
+            Intermediate rows linearly interpolate between dark and full color
+    """
+    if dark_chromaticity is None:
+        dark_chromaticity = np.zeros(3)
+    if color_matrix is None:
+        color_matrix = np.eye(3)
+    if isinstance(gamma, (int, float)):
+        gamma = [gamma, gamma, gamma]
+
+    x = np.linspace(0.0, 1.0, n)
+    corrected = [x ** (1 / g) for g in gamma]
+    rgb = np.column_stack(corrected)
+
+    # RGB->XYZ matrices per entry: linearly interpolate from dark to full color
+    # At x=0: dark chromaticity as diagonal (simplified representation)
+    # At x=1: full color_matrix
+    dark_matrix = np.diag(dark_chromaticity)
+    matrices = x[:, None, None] * (color_matrix - dark_matrix) + dark_matrix
+    matrices_flat = matrices.reshape(n, -1)
+
+    # Combine all columns
+    return np.column_stack([x, rgb, matrices_flat])

--- a/hrl/graphics/graphics.py
+++ b/hrl/graphics/graphics.py
@@ -62,8 +62,9 @@ import numpy as np
 import OpenGL.GL as opengl
 import pygame
 
+from hrl.cluts import gamma_correct_RGB
 from hrl.graphics.texture import Texture, deleteTexture, deleteTextureDL
-from hrl.luts import gamma_correct_grey, gamma_correct_RGB
+from hrl.luts import gamma_correct_grey
 
 
 class Graphics(ABC):

--- a/hrl/hrl.py
+++ b/hrl/hrl.py
@@ -130,7 +130,6 @@ class HRL:
             self.photometer = hrl.photometer.new_photometer(
                 photometer_alias=photometer,
                 device="/dev/ttyUSB0",
-                timeout=10,
             )
 
         ## Results file ##

--- a/hrl/luts.py
+++ b/hrl/luts.py
@@ -53,6 +53,76 @@ def gamma_correct_grey(img, LUT):
     return np.interp(img, LUT[:, 0], LUT[:, 1])
 
 
+def lum_conversion_from_LUT(LUT):
+    """Extract conversion factor and dark luminance from a provided LUT.
+
+    Parameters
+    ----------
+    LUT : Array[float]
+        Lookup Table with shape (N, 3), where
+        the first column is the linearlized input intensities,
+        the second column is the output intensities,
+        and the third column is the luminance values.
+        First row must correspond to zero input intensity (0.0), zero output intensity (0.0),
+        and luminance equal to the dark luminance (cd/m2).
+        This function reads `dark_lum` from the first row
+        and computes the linear conversion using subsequent rows.
+
+    Returns
+    -------
+    conversion : float
+        conversion factor from greyscale to luminance (cd/m2).
+    dark_lum : float
+        luminance value corresponding to zero greyscale (cd/m2).
+    """
+    dark_lum = LUT[0, 2]
+    conversion = (LUT[-1, 2] - dark_lum) / LUT[-1, 0]
+
+    return conversion, dark_lum
+
+
+def grey_to_lum(img, conversion, dark_lum=0.0):
+    """Convert greyscale value(s) to luminance using a provided conversion factor.
+
+    Parameters
+    ----------
+    img : Array[float] or float
+        input greyscale image with values between [0.0, 1.0].
+        Can be a scalar, 1D array, or 2D array.
+    conversion : float
+        conversion factor from greyscale to luminance (cd/m2).
+    dark_lum : float, optional
+        luminance value corresponding to zero greyscale (cd/m2), by default: 0.0 cd/m2
+
+    Returns
+    -------
+    Array[float]
+        output luminance image in cd/m2 with the same shape as input.
+    """
+    return conversion * img + dark_lum
+
+
+def lum_to_grey(lum, conversion, dark_lum=0.0):
+    """Convert luminance value(s) to greyscale using a provided conversion factor.
+
+    Parameters
+    ----------
+    lum : Array[float] or float
+        input luminance value(s) in cd/m2. Can be scalar or any-shaped array.
+    conversion : float
+        conversion factor from greyscale to luminance (cd/m2).
+    dark_lum : float, optional
+        luminance corresponding to zero greyscale (cd/m2), by default: 0.0 cd/m2.
+
+    Returns
+    -------
+    Array[float]
+        greyscale intensity value(s) between [0.0, 1.0] with the same shape as ``lum``.
+    """
+    lum = np.asarray(lum)
+    return (lum - dark_lum) / conversion
+
+
 def create_lut(
     n=256,
     gamma=1.0,

--- a/hrl/luts.py
+++ b/hrl/luts.py
@@ -9,34 +9,23 @@ The greyscale LUTs are structured as 2D NumPy arrays with three columns:
 1: `intensity_out`: Gamma-corrected output intensities
 2: `luminance`: Corresponding luminance values
 
-For color displays, color LUTs (CLUTs) are used,
-which map input R, G, B intensities to linearized RGB values
-and provide a color transformation matrix for each intensity level.
-These CLUTs are structured as 2D NumPy arrays with thirteen columns:
-0: `intensity_in`: Input intensities (ranging between [0.0, 1.0])
-1-3: `R_out`, `G_out`, `B_out`: Gamma-corrected output RGB values
-4-12: 3x3 color transformation (RGB -> XYZ) matrix values, flattened row-wise:
-    [X_R, X_G, X_B, Y_R, Y_G, Y_B, Z_R, Z_G, Z_B]
-
-Generally, these (C)LUTs are created through measurement of a display
+Generally, these LUTs are created through measurement of a display
 and linearization of the resulting measurements.
 This can be done using the `hrl-util`, documented elsewhere.
-Here, we do provide a function to create parametric (C)LUTs
+Here, we do provide a function to create parametric LUTs
 based on standard gamma correction formulas
 -- this is useful for testing and simulation, but should not be used
 for real display characterization!
+
+For color displays, color LUTs (CLUTs) are used, see hrl.cluts for more information.
 
 
 Functions
 ---------
 gamma_correct_grey(img, LUT)
     Apply gamma correction to a greyscale array using a provided LUT.
-gamma_correct_RGB(img, CLUT)
-    Apply gamma correction to an RGB array using a provided color LUT.
 create_lut(n=256, gamma=1.0, k=1.0, dark=0.0)
     Create a parametric LUT with gamma correction and luminance scaling.
-create_clut(n=256, gamma=[1.0, 1.0, 1.0], color_matrix=None, dark_chromaticity=None)
-    Create a parametric CLUT with gamma correction and color conversion.
 
 """
 
@@ -64,41 +53,6 @@ def gamma_correct_grey(img, LUT):
     return np.interp(img, LUT[:, 0], LUT[:, 1])
 
 
-def gamma_correct_RGB(img, CLUT):
-    """Apply gamma correction to an RGB array using a provided color LUT.
-
-    Parameters
-    ----------
-    img : Array[float]
-        input RGB array with values between [0.0, 1.0].
-        Can be a single RGB triplet (shape: (1, 1, 3)) or an RGB image (shape: (H, W, 3)).
-    CLUT : Array[float]
-        Color LookUp Table with at least shape (N, 4), where the first column is
-        input intensities and the next three columns are the corrected R, G, B values.
-        Can have more columns, which will be ignored.
-
-    Returns
-    -------
-    Array[float]
-        gamma-corrected RGB array with the same shape as input.
-    """
-    # Apply interpolation per channel
-    linearized_RGB = np.array(
-        [
-            np.interp(img[..., channel], CLUT[:, 0], CLUT[:, channel + 1])
-            for channel in range(img.shape[-1])
-        ]
-    )
-
-    # Move channel axis from first to last position
-    # For (1, 1, 3) input: (3, 1, 1) -> (1, 1, 3)
-    # For (H, W, 3) input: (3, H, W) -> (H, W, 3)
-    linearized_RGB = np.moveaxis(linearized_RGB, 0, -1)
-
-    return linearized_RGB
-
-
-### (C)LUT Factories ###
 def create_lut(
     n=256,
     gamma=1.0,
@@ -137,53 +91,3 @@ def create_lut(
     out = x ** (1 / gamma)
 
     return np.column_stack([x, out, lum])
-
-
-def create_clut(
-    n=256,
-    gamma=[1.0, 1.0, 1.0],
-    color_matrix=None,
-    dark_chromaticity=None,
-):
-    """Create a parametric CLUT with gamma correction and color conversion.
-
-    Parameters
-    ----------
-    n : int, optional
-        number of entries in the CLUT, by default 256.
-    gamma : [float, float, float] or float, optional
-        gamma exponents for R, G, B correction, by default [1.0, 1.0, 1.0].
-    color_matrix : Array, optional
-        3x3 color transformation matrix, by default identity (XYZ=RGB).
-    dark_chromaticity : Array, optional
-        3-element vector for dark state chromaticity (XYZ at black), by default zeros (no dark light).
-
-    Returns
-    -------
-    Array
-        with 13 columns [intensity_in, R_out, G_out, B_out, 9 matrix values]:
-            R_out, G_out, B_out = intensity_in^(1/gamma[i]) for each channel
-            First row's 3x3 matrix represents dark_chromaticity as the black point
-            Last row's 3x3 matrix is color_matrix
-            Intermediate rows linearly interpolate between dark and full color
-    """
-    if dark_chromaticity is None:
-        dark_chromaticity = np.zeros(3)
-    if color_matrix is None:
-        color_matrix = np.eye(3)
-    if isinstance(gamma, (int, float)):
-        gamma = [gamma, gamma, gamma]
-
-    x = np.linspace(0.0, 1.0, n)
-    corrected = [x ** (1 / g) for g in gamma]
-    rgb = np.column_stack(corrected)
-
-    # RGB->XYZ matrices per entry: linearly interpolate from dark to full color
-    # At x=0: dark chromaticity as diagonal (simplified representation)
-    # At x=1: full color_matrix
-    dark_matrix = np.diag(dark_chromaticity)
-    matrices = x[:, None, None] * (color_matrix - dark_matrix) + dark_matrix
-    matrices_flat = matrices.reshape(n, -1)
-
-    # Combine all columns
-    return np.column_stack([x, rgb, matrices_flat])

--- a/hrl/photometer/__init__.py
+++ b/hrl/photometer/__init__.py
@@ -12,7 +12,7 @@ ALIASES = {
 }
 
 
-def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=10):
+def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=0):
     """Factory function to create a new photometer instance based on the provided name.
 
     Parameters

--- a/hrl/photometer/__init__.py
+++ b/hrl/photometer/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
 ALIASES = {
     "optical": "optical.OptiCAL",
     "minolta": "minolta.Minolta",
-    "i1pro": "i1pro.I1Pro",
+    "i1pro": "i1pro.i1Pro",
 }
 
 
@@ -47,4 +47,4 @@ def new_photometer(photometer_alias, device="/dev/ttyUSB0", timeout=10):
             f"{', '.join(list(ALIASES.keys()))}"
         )
 
-    return photometer_class(device, timeout=timeout)
+    return photometer_class(device=device, timeout=timeout)

--- a/hrl/photometer/__init__.py
+++ b/hrl/photometer/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
 ALIASES = {
     "optical": "optical.OptiCAL",
     "minolta": "minolta.Minolta",
+    "i1pro": "i1pro.I1Pro",
 }
 
 

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -1,7 +1,13 @@
-""" Class to read luminance values with X-Rite i1Pro.
+"""Read luminance and tristimulus values with the X-Rite i1Pro.
 
-It relies on the pypixxlib library from VPixx 
+This module provides the :class:`i1Pro` class, a thin wrapper around the
+X-Rite i1Pro spectrophotometer used for monitor calibration. It exposes
+methods to calibrate the device and to read CIE XYZ tristimulus values as
+well as luminance (the Y tristimulus value, in candela per square meter).
 
+The wrapper relies on the ``pypixxlib`` library from VPixx to talk to the
+device, and on ``pygame`` for timing and keyboard input during the
+interactive calibration steps.
 """
 
 from .photometer import Photometer
@@ -10,6 +16,25 @@ import pygame
 import numpy as np
 
 def wait_any_button(timeout=0):
+    """Block until a key is pressed or an optional timeout elapses.
+
+    Polls the ``pygame`` event queue and returns as soon as a key is pressed. 
+    This is used to pause execution during calibration so the
+    experimenter can place move the device and confirm they are ready to continue.
+
+    Note that a working ``pygame`` display and event loop must be initialised
+    by the caller for the keyboard events to be delivered.
+
+    Parameters
+    ----------
+    timeout : int, optional
+        Maximum time to wait, in milliseconds. If ``0`` (the default) the
+        function waits indefinitely until a key is pressed.
+
+    Returns
+    -------
+    None
+    """
     t0 = pygame.time.get_ticks()
     btn = None
     while (timeout == 0) or (pygame.time.get_ticks() - t0 < timeout):
@@ -19,19 +44,65 @@ def wait_any_button(timeout=0):
         
         
 class i1Pro(Photometer):
+    """Photometer driver for the X-Rite i1Pro spectrophotometer.
+
+    Concrete implementation of the :class:`~hrl.photometer.photometer.Photometer`
+    abstract base class for the X-Rite i1Pro. On construction the device is
+    connected, its colour space is set to CIE XYZ and a calibration is performed,
+    so that the instance is ready to take measurements. The device is calibrated
+    for measurements of emitting surfaces, i.e. monitors.
+
+    Measurements are returned either as full CIE XYZ tristimulus values (see
+    :meth:`readTristimulus`) or as luminance alone (see :meth:`readLuminance`),
+    with luminance defined as the Y tristimulus value in candela per square
+    meter.
+
+    Attributes
+    ----------
+    phtm : pypixxlib.i1.I1Pro
+        The underlying VPixx device handle used for all hardware operations.
+    """
+
     def __init__(self, timeout=5):
+        """Connect to the i1Pro, set the colour space and calibrate it.
+
+        Opens a connection to the device, prints its revision and serial
+        number, configures the ``CIEXYZ`` colour space and immediately runs
+        the calibration method.
+
+        Parameters
+        ----------
+        timeout : int, optional
+            Reserved for interface compatibility, not currently used.
+        """
         super(i1Pro, self).__init__()
         self.phtm = I1Pro()
-        
+
         print("i1Pro device connected")
         print(f"revision: {self.phtm.revision} - serial number: {self.phtm.serial_number}")
         self.phtm.setColorSpace("CIEXYZ")
-     
-        # check if calibration is necessary
+
+        # calibrate always at the start
         self.calibrate()
                       
         
     def calibrate(self):
+        """Run a calibration of the device.
+
+        Prompts the experimenter to place the i1Pro on its calibration nest
+        and press the side button, then performs a calibration.
+        The current colour space, measurement mode and illumination mode are
+        printed for reference. Finally it waits (via :func:`wait_any_button`)
+        for the experimenter to place the device on the screen and press any
+        key before measurements begin.
+
+        This method is called automatically at construction time and again by
+        :meth:`readTristimulus` whenever the previous calibration has expired.
+
+        Returns
+        -------
+        None
+        """
         print('****************************************************')
         print("Calibrating device, put the device on its nest and push the side button")
         self.phtm.calibrate("Emission")
@@ -45,9 +116,34 @@ class i1Pro(Photometer):
         print('Put the device on the screen to be measured and press any key to start / continue the measurements')
         wait_any_button(timeout=0)
 
-
     def readTristimulus(self, n=3, slp=1, verbose=False):
-        
+        """Read CIE XYZ tristimulus values from the device.
+
+        Re-calibrates first if the device reports that its calibration has
+        expired. Then attempts up to ``n`` measurements, returning the XYZ
+        values of the first successful reading. If a measurement raises an
+        error the attempt is retried; if every attempt fails, ``numpy.nan``
+        is returned.
+
+        Parameters
+        ----------
+        n : int, optional
+            Maximum number of measurement attempts before giving up.
+            Defaults is ``3``.
+        slp : int, optional
+            Delay in milliseconds inserted before each measurement attempt,
+            applied via ``pygame.time.delay``. Defaults is ``1``.
+        verbose : bool, optional
+            If ``True``, print the measured X, Y and Z values to console. 
+            Default is ``False``.
+
+        Returns
+        -------
+        tuple of float or float
+            The ``(X, Y, Z)`` tristimulus values from the first successful
+            measurement, or ``numpy.nan`` if all ``n`` attempts failed.
+        """
+
         # check if calibration is needed
         if self.phtm.isCalibrationExpired():
             self.calibrate()
@@ -63,22 +159,47 @@ class i1Pro(Photometer):
                 if verbose:
                     print('Tristimulus values:')
                     print(f"X: {X}, Y: {Y}, Z:{Z}")
-                              
-                                         
+                                                  
                 return X, Y, Z
             except:
                 print("Error in reading from instrument")
         # if no try was successful
-        return np.nan
+        return np.nan, np.nan, np.nan
         
         
     def readLuminance(self, n=3, slp=1, verbose=False):
-        
+        """Read the luminance from the device, in candela per square meter.
+
+        Convenience wrapper around :meth:`readTristimulus` that returns only
+        the Y tristimulus value, which is luminance by definition in the CIE
+        XYZ colour space.
+
+        Parameters
+        ----------
+        n : int, optional
+            Maximum number of measurement attempts before giving up.
+            Defaults to ``3``.
+        slp : int, optional
+            Delay in milliseconds inserted before each measurement attempt.
+            Defaults to ``1``.
+        verbose : bool, optional
+            If ``True``, print the measured X, Y and Z values. Defaults to
+            ``False``.
+
+        Returns
+        -------
+        float
+            The luminance (Y) in candela per square meter. If every
+            measurement attempt fails, :meth:`readTristimulus` returns
+            ``numpy.nan`` and this method will raise a ``TypeError`` while
+            unpacking, so callers should ensure the device is measuring
+            correctly.
+        """
         # reads tristimulus values X, Y, Z.
         _, lum, _ = self.readTristimulus(n=n, slp=slp, verbose=verbose)
-        
-        # returns Y, which is luminance by definition.    
-        return lum       
+
+        # returns Y, which is luminance by definition.
+        return lum
 
         
 

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -10,15 +10,17 @@ device, and on ``pygame`` for timing and keyboard input during the
 interactive calibration steps.
 """
 
-from .photometer import Photometer
-from pypixxlib.i1 import I1Pro
-import pygame
 import numpy as np
+import pygame
+from pypixxlib.i1 import I1Pro
+
+from .photometer import Photometer
+
 
 def wait_any_button(timeout=0):
     """Block until a key is pressed or an optional timeout elapses.
 
-    Polls the ``pygame`` event queue and returns as soon as a key is pressed. 
+    Polls the ``pygame`` event queue and returns as soon as a key is pressed.
     This is used to pause execution during calibration so the
     experimenter can place move the device and confirm they are ready to continue.
 
@@ -41,8 +43,8 @@ def wait_any_button(timeout=0):
         event = pygame.event.wait(1)  # waits for only 1 ms
         if event.type == pygame.KEYDOWN:
             break
-        
-        
+
+
 class i1Pro(Photometer):
     """Photometer driver for the X-Rite i1Pro spectrophotometer.
 
@@ -84,8 +86,7 @@ class i1Pro(Photometer):
 
         # calibrate always at the start
         self.calibrate()
-                      
-        
+
     def calibrate(self):
         """Run a calibration of the device.
 
@@ -103,17 +104,19 @@ class i1Pro(Photometer):
         -------
         None
         """
-        print('****************************************************')
+        print("****************************************************")
         print("Calibrating device, put the device on its nest and push the side button")
         self.phtm.calibrate("Emission")
-        
+
         print(f"Current color space is {self.phtm.getColorSpace()}")
         print(f"Current measurement mode is {self.phtm.getMeasurementMode()}")
         print(f"Current illumination mode is {self.phtm.getIlluminationMode()}")
         print("... Calibration done.")
-        print('****************************************************')
-        print('')
-        print('Put the device on the screen to be measured and press any key to start / continue the measurements')
+        print("****************************************************")
+        print("")
+        print(
+            "Put the device on the screen to be measured and press any key to start / continue the measurements"
+        )
         wait_any_button(timeout=0)
 
     def readTristimulus(self, n=3, slp=1, verbose=False):
@@ -134,7 +137,7 @@ class i1Pro(Photometer):
             Delay in milliseconds inserted before each measurement attempt,
             applied via ``pygame.time.delay``. Defaults is ``1``.
         verbose : bool, optional
-            If ``True``, print the measured X, Y and Z values to console. 
+            If ``True``, print the measured X, Y and Z values to console.
             Default is ``False``.
 
         Returns
@@ -147,26 +150,25 @@ class i1Pro(Photometer):
         # check if calibration is needed
         if self.phtm.isCalibrationExpired():
             self.calibrate()
-            
+
         # do measurements
         for i in range(n):
             try:
                 pygame.time.delay(slp)
-                
+
                 # measure the XYZ tristimulus values
                 self.phtm.runMeasurement()
                 X, Y, Z = self.phtm.getLatestTriStimulusMeasurements()
                 if verbose:
-                    print('Tristimulus values:')
+                    print("Tristimulus values:")
                     print(f"X: {X}, Y: {Y}, Z:{Z}")
-                                                  
+
                 return X, Y, Z
             except:
                 print("Error in reading from instrument")
         # if no try was successful
         return np.nan, np.nan, np.nan
-        
-        
+
     def readLuminance(self, n=3, slp=1, verbose=False):
         """Read the luminance from the device, in candela per square meter.
 
@@ -200,6 +202,3 @@ class i1Pro(Photometer):
 
         # returns Y, which is luminance by definition.
         return lum
-
-        
-

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -14,7 +14,7 @@ import numpy as np
 import pygame
 from pypixxlib.i1 import I1Pro
 
-from .photometer import Photometer
+from .photometer import Colorimeter
 
 
 def wait_any_button(timeout=0):
@@ -45,10 +45,10 @@ def wait_any_button(timeout=0):
             break
 
 
-class i1Pro(Photometer):
-    """Photometer driver for the X-Rite i1Pro spectrophotometer.
+class i1Pro(Colorimeter):
+    """Colorimeter driver for the X-Rite i1Pro spectrophotometer.
 
-    Concrete implementation of the :class:`~hrl.photometer.photometer.Photometer`
+    Concrete implementation of the :class:`~hrl.photometer.photometer.Colorimeter`
     abstract base class for the X-Rite i1Pro. On construction the device is
     connected, its colour space is set to CIE XYZ and a calibration is performed,
     so that the instance is ready to take measurements. The device is calibrated
@@ -168,37 +168,3 @@ class i1Pro(Photometer):
                 print("Error in reading from instrument")
         # if no try was successful
         return np.nan, np.nan, np.nan
-
-    def readLuminance(self, n=3, slp=1, verbose=False):
-        """Read the luminance from the device, in candela per square meter.
-
-        Convenience wrapper around :meth:`readTristimulus` that returns only
-        the Y tristimulus value, which is luminance by definition in the CIE
-        XYZ colour space.
-
-        Parameters
-        ----------
-        n : int, optional
-            Maximum number of measurement attempts before giving up.
-            Defaults to ``3``.
-        slp : int, optional
-            Delay in milliseconds inserted before each measurement attempt.
-            Defaults to ``1``.
-        verbose : bool, optional
-            If ``True``, print the measured X, Y and Z values. Defaults to
-            ``False``.
-
-        Returns
-        -------
-        float
-            The luminance (Y) in candela per square meter. If every
-            measurement attempt fails, :meth:`readTristimulus` returns
-            ``numpy.nan`` and this method will raise a ``TypeError`` while
-            unpacking, so callers should ensure the device is measuring
-            correctly.
-        """
-        # reads tristimulus values X, Y, Z.
-        _, lum, _ = self.readTristimulus(n=n, slp=slp, verbose=verbose)
-
-        # returns Y, which is luminance by definition.
-        return lum

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -1,0 +1,84 @@
+""" Class to read luminance values with X-Rite i1Pro.
+
+It relies on the pypixxlib library from VPixx 
+
+"""
+
+from .photometer import Photometer
+from pypixxlib.i1 import I1Pro
+import pygame
+import numpy as np
+
+def wait_any_button(timeout=0):
+    t0 = pygame.time.get_ticks()
+    btn = None
+    while (timeout == 0) or (pygame.time.get_ticks() - t0 < timeout):
+        event = pygame.event.wait(1)  # waits for only 1 ms
+        if event.type == pygame.KEYDOWN:
+            break
+        
+        
+class i1Pro(Photometer):
+    def __init__(self, timeout=5):
+        super(i1Pro, self).__init__()
+        self.phtm = I1Pro()
+        
+        print("i1Pro device connected")
+        print(f"revision: {self.phtm.revision} - serial number: {self.phtm.serial_number}")
+        self.phtm.setColorSpace("CIEXYZ")
+     
+        # check if calibration is necessary
+        self.calibrate()
+                      
+        
+    def calibrate(self):
+        print('****************************************************')
+        print("Calibrating device, put the device on its nest and push the side button")
+        self.phtm.calibrate("Emission")
+        
+        print(f"Current color space is {self.phtm.getColorSpace()}")
+        print(f"Current measurement mode is {self.phtm.getMeasurementMode()}")
+        print(f"Current illumination mode is {self.phtm.getIlluminationMode()}")
+        print("... Calibration done.")
+        print('****************************************************')
+        print('')
+        print('Put the device on the screen to be measured and press any key to start / continue the measurements')
+        wait_any_button(timeout=0)
+
+
+    def readTristimulus(self, n=3, slp=1, verbose=False):
+        
+        # check if calibration is needed
+        if self.phtm.isCalibrationExpired():
+            self.calibrate()
+            
+        # do measurements
+        for i in range(n):
+            try:
+                pygame.time.delay(slp)
+                
+                # measure the XYZ tristimulus values
+                self.phtm.runMeasurement()
+                X, Y, Z = self.phtm.getLatestTriStimulusMeasurements()
+                if verbose:
+                    print('Tristimulus values:')
+                    print(f"X: {X}, Y: {Y}, Z:{Z}")
+                              
+                                         
+                return X, Y, Z
+            except:
+                print("Error in reading from instrument")
+        # if no try was successful
+        return np.nan
+        
+        
+    def readLuminance(self, n=3, slp=1, verbose=False):
+        
+        # reads tristimulus values X, Y, Z.
+        _, lum, _ = self.readTristimulus(n=n, slp=slp, verbose=verbose)
+        
+        # returns Y, which is luminance by definition.    
+        return lum       
+
+        
+

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -65,7 +65,7 @@ class i1Pro(Photometer):
         The underlying VPixx device handle used for all hardware operations.
     """
 
-    def __init__(self, timeout=0):
+    def __init__(self, device=None, timeout=0):
         """Connect to the i1Pro, set the colour space and calibrate it.
 
         Opens a connection to the device, prints its revision and serial

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -65,7 +65,7 @@ class i1Pro(Photometer):
         The underlying VPixx device handle used for all hardware operations.
     """
 
-    def __init__(self, timeout=5):
+    def __init__(self, timeout=0):
         """Connect to the i1Pro, set the colour space and calibrate it.
 
         Opens a connection to the device, prints its revision and serial
@@ -85,9 +85,9 @@ class i1Pro(Photometer):
         self.phtm.setColorSpace("CIEXYZ")
 
         # calibrate always at the start
-        self.calibrate()
+        self.calibrate(timeout=timeout)
 
-    def calibrate(self):
+    def calibrate(self, timeout=0):
         """Run a calibration of the device.
 
         Prompts the experimenter to place the i1Pro on its calibration nest
@@ -117,7 +117,7 @@ class i1Pro(Photometer):
         print(
             "Put the device on the screen to be measured and press any key to start / continue the measurements"
         )
-        wait_any_button(timeout=0)
+        wait_any_button(timeout=timeout)
 
     def readTristimulus(self, n=3, slp=1, verbose=False):
         """Read CIE XYZ tristimulus values from the device.

--- a/hrl/photometer/i1pro.py
+++ b/hrl/photometer/i1pro.py
@@ -112,12 +112,13 @@ class i1Pro(Colorimeter):
         print(f"Current measurement mode is {self.phtm.getMeasurementMode()}")
         print(f"Current illumination mode is {self.phtm.getIlluminationMode()}")
         print("... Calibration done.")
-        print("****************************************************")
-        print("")
-        print(
-            "Put the device on the screen to be measured and press any key to start / continue the measurements"
-        )
-        wait_any_button(timeout=timeout)
+        print("****************************************************\n")
+        print("Put the device on the screen to be measured.\n")
+
+        # wait_any_button(timeout=timeout)
+        user_input = None
+        while user_input is not "Y":
+            user_input = input("Ready to continue measurement? [Y/n]") or "Y"
 
     def readTristimulus(self, n=3, slp=1, verbose=False):
         """Read CIE XYZ tristimulus values from the device.

--- a/hrl/photometer/photometer.py
+++ b/hrl/photometer/photometer.py
@@ -8,6 +8,8 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
+from hrl.cluts import RGB_to_XYZ, XYZ_from_CLUT, gamma_correct_RGB
+
 
 class Photometer(ABC):
     """
@@ -172,3 +174,56 @@ class Colorimeter(Photometer):
 
         # returns Y, which is luminance by definition.
         return lum
+
+
+class MockColorimeter(Colorimeter):
+    def __init__(self, color_mapping=None, noise=0.0, rng=None):
+        super().__init__()
+        self.current_triplet = [0.0, 0.0, 0.0]  # Current RGB triplet
+        self.noise = noise
+        self.rng = np.random.default_rng(rng)
+
+        if callable(color_mapping):
+            self._clut_func = color_mapping
+        elif color_mapping.shape[1] == 4:
+            # 4-column LUT (intensity_in, R_out, G_out, B_out):
+            # can only correct, not convert to XYZ, so we just use the gamma_correct_RGB function.
+            # implicitly assumes that the color matrix is identity and dark chromaticity is zero.
+            clut = np.asarray(color_mapping)
+            self._clut_func = lambda r, g, b: gamma_correct_RGB(
+                np.array([r, g, b]).reshape(1, 1, 3), clut
+            ).flatten()
+        elif color_mapping.shape[1] == 13:
+            # Full 13-column LUT (intensity_in, R_out, G_out, B_out, and 9 columns for color matrix):
+            clut = np.asarray(color_mapping)
+            color_matrix, dark_chromaticity = XYZ_from_CLUT(clut)
+            self._clut_func = lambda r, g, b: RGB_to_XYZ(
+                gamma_correct_RGB(np.array([r, g, b]).reshape(1, 1, 3), clut),
+                color_matrix=color_matrix,
+                dark_chromaticity=dark_chromaticity,
+            ).flatten()
+        else:
+            raise ValueError(
+                "color_mapping must be a callable or an array-like with 4 or 13 columns."
+            )
+
+    def readTristimulus(self, n=3, slp=None):
+        """Return simulated CIE XYZ tristimulus values for the currently displayed RGB triplet.
+
+        Parameters
+        ----------
+        n : int
+            Number of samples to average (mirrors the real photometer API).
+        slp : int
+            Sleep time between samples in ms (ignored in mock).
+
+        Returns
+        -------
+        tuple of float
+            Simulated CIE XYZ tristimulus values, averaged over ``n`` samples.
+        """
+        base_XYZ = self._clut_func(*self.current_triplet)
+        if self.noise > 0.0:
+            samples = base_XYZ + self.rng.normal(0.0, self.noise, size=(n, 3))
+            return tuple(np.mean(samples, axis=0))
+        return tuple(base_XYZ)

--- a/hrl/photometer/photometer.py
+++ b/hrl/photometer/photometer.py
@@ -115,3 +115,60 @@ class MockPhotometer(Photometer):
             samples = base_lum + self.rng.normal(0.0, self.noise, size=n)
             return float(np.mean(samples))
         return base_lum
+
+
+class Colorimeter(Photometer):
+    """Abstract Base Class for Colorimeter devices that can measure CIE XYZ Tristimulus values
+
+    Cannot be instantiated directly -- instead need to subclass
+    and implement the abstract method :meth:`readTristimulus`.
+
+    NOTE: Since Y is the luminance component by definition in the CIE XYZ colour space,
+    all Colorimeters are also Photometers.
+    This ABC implements the :meth:`readLuminance` method to return the Y tristimulus value.
+    """
+
+    @abstractmethod
+    def readTristimulus(self, n=3, slp=1):
+        """Take colorimetric measurements and return the CIE XYZ tristimulus values.
+
+        Parameters
+        ----------
+        n : int, optional
+            Maximum number of measurement attempts before giving up, by defaults 3.
+        slp : int, optional
+            Delay in milliseconds inserted before each measurement attempt, by default 1.
+
+        Returns
+        -------
+        tuple of float
+            ``(X, Y, Z)`` tristimulus values from the first successful mmeasurement,
+            or ``numpy.nan`` if all ``n`` attempts failed.
+        """
+        ...
+
+    def readLuminance(self, n=3, slp=1):
+        """Take colorimetric measurements and return the luminance in candela per square meter.
+
+        Convenience wrapper around :meth:`readTristimulus`
+        that returns only the Y tristimulus value,
+        which is luminance by definition in the CIE XYZ colour space.
+
+        Parameters
+        ----------
+        n : int, optional
+            Maximum number of measurement attempts before giving up, by defaults 3.
+        slp : int, optional
+            Delay in milliseconds inserted before each measurement attempt, by default 1.
+
+        Returns
+        -------
+        float
+            Luminance (Y) in candela per square meter from the first successful measurement,
+            or ``numpy.nan`` if all ``n`` attempts failed.
+        """
+        # reads tristimulus values X, Y, Z.
+        _, lum, _ = self.readTristimulus(n=n, slp=slp)
+
+        # returns Y, which is luminance by definition.
+        return lum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,14 @@ from hrl.luts import create_lut
 
 # Standard gamma exponent for all gamma-related fixtures and tests
 DEFAULT_GAMMA = 2.2
+DARK_CHROMATICITY = np.array([0.01, 0.012, 0.015])
+COLOR_MATRIX = np.array(
+    [
+        [0.85, 0.05, 0.01],
+        [0.03, 0.87, 0.04],
+        [0.02, 0.06, 0.84],
+    ]
+)
 
 
 def pytest_addoption(parser):
@@ -28,7 +36,7 @@ def photometer_dev(request):
 
 
 @pytest.fixture
-def no_lut():
+def identity_lut():
     """Simple pass-through LUT with no gamma correction and no dark luminance.
 
     Returns
@@ -73,7 +81,7 @@ def nonlinear_lut():
 
 
 @pytest.fixture
-def no_clut():
+def identity_clut():
     """Simple pass-through CLUT with no gamma correction and no dark chromaticity.
 
     Returns
@@ -97,8 +105,21 @@ def linear_clut():
         R_out = G_out = B_out = intensity_in^(1/1.0) = intensity_in.
         Dark chromaticity: small nonzero values. Color matrix: identity.
     """
-    dark = np.array([0.01, 0.012, 0.015])
-    return create_clut(gamma=1.0, dark_chromaticity=dark, color_matrix=np.eye(3))
+    return create_clut(gamma=1.0, dark_chromaticity=DARK_CHROMATICITY, color_matrix=np.eye(3))
+
+
+@pytest.fixture
+def linear_conversion_clut():
+    """Linear CLUT with channel crosstalk, no gamma correction, no dark chromaticity.
+
+    Returns
+    -------
+    Array
+        with 13 columns [intensity_in, R_out, G_out, B_out, 9 matrix values].
+        R_out = G_out = B_out = intensity_in^(1/1.0) = intensity_in.
+        Dark chromaticity: zeroes. Color matrix: simulates channel crosstalk.
+    """
+    return create_clut(gamma=1.0, dark_chromaticity=np.zeros(3), color_matrix=COLOR_MATRIX)
 
 
 @pytest.fixture
@@ -112,12 +133,6 @@ def nonlinear_clut():
         R_out = G_out = B_out = intensity_in^(1/2.2).
         Dark chromaticity: small nonzero values. Color matrix: simulates channel crosstalk.
     """
-    dark = np.array([0.01, 0.012, 0.015])
-    color_matrix = np.array(
-        [
-            [0.85, 0.05, 0.01],
-            [0.03, 0.87, 0.04],
-            [0.02, 0.06, 0.84],
-        ]
+    return create_clut(
+        gamma=DEFAULT_GAMMA, dark_chromaticity=DARK_CHROMATICITY, color_matrix=COLOR_MATRIX
     )
-    return create_clut(gamma=DEFAULT_GAMMA, dark_chromaticity=dark, color_matrix=color_matrix)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from hrl.luts import create_clut, create_lut
+from hrl.cluts import create_clut
+from hrl.luts import create_lut
 
 # Standard gamma exponent for all gamma-related fixtures and tests
 DEFAULT_GAMMA = 2.2

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,146 @@
+import numpy as np
+import pytest
+
+from hrl.cluts import RGB_to_XYZ, XYZ_from_CLUT, XYZ_to_RGB, invert_color_matrix
+from hrl.luts import grey_to_lum, lum_conversion_from_LUT, lum_to_grey
+
+
+@pytest.mark.parametrize(
+    "grey,k,dark",
+    [
+        (0.0, 50.0, 0.5),
+        (0.25, 120.0, 1.5),
+        (0.75, 10.0, 0.0),
+        (1.0, 200.0, 2.0),
+    ],
+)
+def test_luminance_conversion_roundtrip_scalar(grey, k, dark):
+    lum = grey_to_lum(grey, k, dark)
+    grey_back = lum_to_grey(lum, k, dark)
+    np.testing.assert_allclose(grey_back, grey, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "shape,k,dark",
+    [
+        ((2, 3), 50.0, 0.5),
+        ((4, 1), 120.0, 1.5),
+    ],
+)
+def test_luminance_conversion_roundtrip_array(shape, k, dark):
+    rng = np.random.default_rng(hash((shape, k, dark)) % (2**32))
+    grey = rng.uniform(0.0, 1.0, size=shape)
+    lum = grey_to_lum(grey, k, dark)
+    grey_back = lum_to_grey(lum, k, dark)
+    np.testing.assert_allclose(grey_back, grey, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "k,dark,n_points",
+    [
+        (100.0, 2.0, 10),
+        (75.0, 0.5, 6),
+        (150.0, 5.0, 12),
+    ],
+)
+def test_lum_conversion_from_LUT(k, dark, n_points):
+    # LUT columns: [linearized_input, output, luminance]
+    # Convention: first row must be zero-intensity with luminance = dark
+    x = np.linspace(0.0, 1.0, n_points)
+    out = x  # corrected output intensities
+    lum = k * x + dark
+    lum[0] = dark  # ensure zero row encodes the dark luminance
+    lut = np.column_stack([x, out, lum])
+
+    conversion, dark_lum = lum_conversion_from_LUT(lut)
+
+    np.testing.assert_allclose(conversion, k, atol=1e-12)
+    np.testing.assert_allclose(dark_lum, dark, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,shape",
+    [
+        (0, (4, 5, 3)),
+        (1, (2, 3, 3)),
+    ],
+)
+def test_XYZ_RGB_conversion_roundtrip_image(seed, shape):
+    rng = np.random.default_rng(seed)
+    M = rng.random((3, 3))
+    invM = invert_color_matrix(M)
+
+    dark = np.zeros((3, 3))
+    rgb = rng.random(shape)
+
+    xyz = RGB_to_XYZ(rgb, M, dark)
+    rgb_back = XYZ_to_RGB(xyz, invM, dark)
+
+    np.testing.assert_allclose(rgb_back, rgb, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "M,dark",
+    [
+        (
+            np.array([[0.9, 0.1, 0.0], [0.2, 0.7, 0.1], [0.0, 0.3, 0.8]]),
+            np.array([[0.01, 0.02, 0.03], [0.04, 0.05, 0.06], [0.07, 0.08, 0.09]]),
+        ),
+        (
+            np.eye(3) * 0.8,
+            np.array([[0.0, 0.0, 0.0], [0.02, 0.0, 0.01], [0.0, 0.03, 0.0]]),
+        ),
+    ],
+)
+def test_XYZ_from_CLUT(M, dark):
+    x = np.linspace(0.0, 1.0, 5)
+    rgb = np.column_stack([x, x, x])
+
+    rows = []
+    for i, xi in enumerate(x):
+        if i == 0:
+            mat = dark
+        elif i == len(x) - 1:
+            mat = M
+        else:
+            mat = np.zeros((3, 3))
+        row = np.concatenate([[xi], rgb[i], mat.reshape(-1)])
+        rows.append(row)
+    CLUT = np.vstack(rows)
+
+    color_matching_matrix, dark_chromaticity = XYZ_from_CLUT(CLUT)
+
+    np.testing.assert_allclose(color_matching_matrix, M, atol=1e-12)
+    np.testing.assert_allclose(dark_chromaticity, dark, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "dark",
+    [
+        np.array([[0.1, 0.0, 0.0], [0.0, 0.2, 0.0], [0.0, 0.0, 0.3]]),
+        np.array([[0.0, 0.05, 0.0], [0.01, 0.0, 0.02], [0.0, 0.0, 0.0]]),
+    ],
+)
+def test_RGB_to_XYZ_adds_dark_chromaticity(dark):
+    M = np.eye(3)
+    add_vec = dark.sum(axis=0)
+    rgb = np.array([[[0.2, 0.4, 0.6]]])
+    xyz = RGB_to_XYZ(rgb, M, dark)
+    np.testing.assert_allclose(xyz, rgb + add_vec, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "dark",
+    [
+        np.array([[0.05, 0.01, 0.02], [0.0, 0.03, 0.0], [0.0, 0.0, 0.04]]),
+        np.array([[0.0, 0.0, 0.0], [0.02, 0.0, 0.01], [0.0, 0.03, 0.0]]),
+    ],
+)
+def test_XYZ_to_RGB_subtracts_dark_chromaticity(dark):
+    M = np.eye(3)
+    invM = invert_color_matrix(M)
+    sub_vec = dark.sum(axis=0)
+    rgb = np.array([[[0.3, 0.2, 0.1]]])
+    xyz = rgb + sub_vec
+    rgb_back = XYZ_to_RGB(xyz, invM, dark)
+    np.testing.assert_allclose(rgb_back, rgb, atol=1e-12)

--- a/tests/test_gamma_correct_RGB.py
+++ b/tests/test_gamma_correct_RGB.py
@@ -16,12 +16,12 @@ from hrl.cluts import gamma_correct_RGB
     ],
     ids=["black", "low_grey", "mid_grey", "high_grey", "white"],
 )
-def test_gamma_correct_RGB_triplet_no_clut(input_RGB, no_clut):
+def test_gamma_correct_RGB_triplet_no_clut(input_RGB, identity_clut):
     """Test gamma correction on RGB triplet with no_clut (gamma=1.0)."""
     rgb_triplet = np.reshape(input_RGB, (1, 1, 3))
 
     # Linearize RGB triplet using CLUT
-    linearized_RGB = gamma_correct_RGB(rgb_triplet, no_clut)
+    linearized_RGB = gamma_correct_RGB(rgb_triplet, identity_clut)
 
     # Test output shape
     assert linearized_RGB.shape == (1, 1, 3)
@@ -93,15 +93,15 @@ def test_gamma_correct_RGB_triplet_nonlinear_clut(input_RGB, nonlinear_clut):
     ],
     ids=["small_square", "rectangular", "single_pixel", "large_square"],
 )
-def test_gamma_correct_RGB_img_no_clut(shape, no_clut):
-    """Test gamma correction on 3D RGB image arrays with no_clut (gamma=1.0)."""
+def test_gamma_correct_RGB_img_no_clut(shape, identity_clut):
+    """Test gamma correction on 3D RGB image arrays with identity_clut (gamma=1.0)."""
     # Generate a test RGB image array with deterministic seed
     seed = hash(shape) % (2**32)
     rng = np.random.default_rng(seed)
     rgb_img = rng.uniform(0, 1, size=(*shape, 3))
 
     # Linearize RGB image array using CLUT
-    linearized_img = gamma_correct_RGB(rgb_img, no_clut)
+    linearized_img = gamma_correct_RGB(rgb_img, identity_clut)
 
     # Test output shape
     assert linearized_img.shape == (*shape, 3)

--- a/tests/test_gamma_correct_RGB.py
+++ b/tests/test_gamma_correct_RGB.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from conftest import DEFAULT_GAMMA
 
-from hrl.luts import gamma_correct_RGB
+from hrl.cluts import gamma_correct_RGB
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gamma_correct_grey.py
+++ b/tests/test_gamma_correct_grey.py
@@ -16,9 +16,9 @@ from hrl.luts import gamma_correct_grey
     ],
     ids=["black", "low_grey", "mid_grey", "high_grey", "white"],
 )
-def test_gamma_correct_grey_no_lut(input_intensity, no_lut):
-    """Test gamma correction with no_lut (gamma=1.0, k=1.0, dark=0.0)."""
-    linearized_intensity = gamma_correct_grey(input_intensity, no_lut)
+def test_gamma_correct_grey_identity(input_intensity, identity_lut):
+    """Test gamma correction with identity_lut (gamma=1.0, k=1.0, dark=0.0)."""
+    linearized_intensity = gamma_correct_grey(input_intensity, identity_lut)
 
     # Test output is scalar
     assert np.isscalar(linearized_intensity)
@@ -27,7 +27,7 @@ def test_gamma_correct_grey_no_lut(input_intensity, no_lut):
     assert np.array_equal(linearized_intensity, input_intensity)
 
     # Check expected luminance
-    actual_luminance = np.interp(input_intensity, no_lut[:, 0], no_lut[:, 2])
+    actual_luminance = np.interp(input_intensity, identity_lut[:, 0], identity_lut[:, 2])
     assert np.array_equal(actual_luminance, input_intensity)
 
 
@@ -90,15 +90,15 @@ def test_gamma_correct_grey_nonlinear_lut(
     [(5, 5), (10, 8), (1, 1), (50, 50)],
     ids=["small_square", "rectangular", "single_pixel", "large_square"],
 )
-def test_gamma_correct_grey_img_no_lut(shape, no_lut):
-    """Test gamma correction on 2D greyscale image arrays with no_lut (gamma=1.0, k=1.0, dark=0.0)."""
+def test_gamma_correct_grey_img_identity(shape, identity_lut):
+    """Test gamma correction on 2D greyscale image arrays with identity_lut (gamma=1.0, k=1.0, dark=0.0)."""
     # Generate a test greyscale image array with deterministic seed
     seed = hash(shape) % (2**32)
     rng = np.random.default_rng(seed)
     grey_img = rng.uniform(0, 1, size=shape)
 
     # Linearize grey image array using LUT
-    linearized_img = gamma_correct_grey(grey_img, no_lut)
+    linearized_img = gamma_correct_grey(grey_img, identity_lut)
 
     # Test output shape
     assert linearized_img.shape == shape

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytestmark = [pytest.mark.photometer]
+
+
+def test_initialization(photometer_dev):
+    from hrl.photometer.i1pro import i1Pro
+
+    i1Pro()
+
+
+def test_read_luminance(photometer_dev):
+    from hrl.photometer.i1pro import i1Pro
+
+    device = i1Pro()
+    device.readLuminance(n=1, slp=5)

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -1,16 +1,15 @@
+import pygame
 import pytest
+from hrl.photometer.i1pro import i1Pro
 
 pytestmark = [pytest.mark.photometer]
+pygame.init()
 
 
-def test_initialization(photometer_dev):
-    from hrl.photometer.i1pro import i1Pro
-
-    i1Pro()
+def test_initialization():
+    i1Pro(timeout=1)
 
 
-def test_read_luminance(photometer_dev):
-    from hrl.photometer.i1pro import i1Pro
-
-    device = i1Pro()
+def test_read_luminance():
+    device = i1Pro(timeout=1)
     device.readLuminance(n=1, slp=5)

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -18,7 +18,8 @@ def test_alias():
 
 def test_read_luminance():
     device = i1Pro(timeout=1)
-    device.readLuminance(n=1, slp=5)
+    lum = device.readLuminance(n=1, slp=5)
+    assert isinstance(lum, float)
 
 
 def test_read_tristimulus():

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -1,5 +1,7 @@
 import pygame
 import pytest
+
+import hrl.photometer
 from hrl.photometer.i1pro import i1Pro
 
 pytestmark = [pytest.mark.photometer]
@@ -8,6 +10,10 @@ pygame.init()
 
 def test_initialization():
     i1Pro(timeout=1)
+
+
+def test_alias():
+    hrl.photometer.new_photometer("i1pro", timeout=1)
 
 
 def test_read_luminance():

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -19,3 +19,10 @@ def test_alias():
 def test_read_luminance():
     device = i1Pro(timeout=1)
     device.readLuminance(n=1, slp=5)
+
+
+def test_read_tristimulus():
+    device = i1Pro(timeout=1)
+    xyz = device.readTristimulus(n=1, slp=5)
+    assert isinstance(xyz, tuple)
+    assert len(xyz) == 3

--- a/tests/test_i1pro.py
+++ b/tests/test_i1pro.py
@@ -2,13 +2,14 @@ import pygame
 import pytest
 
 import hrl.photometer
-from hrl.photometer.i1pro import i1Pro
 
 pytestmark = [pytest.mark.photometer]
 pygame.init()
 
 
 def test_initialization():
+    from hrl.photometer.i1pro import i1Pro
+
     i1Pro(timeout=1)
 
 
@@ -17,13 +18,15 @@ def test_alias():
 
 
 def test_read_luminance():
-    device = i1Pro(timeout=1)
+    device = hrl.photometer.new_photometer("i1pro", timeout=1)
+
     lum = device.readLuminance(n=1, slp=5)
     assert isinstance(lum, float)
 
 
 def test_read_tristimulus():
-    device = i1Pro(timeout=1)
+    device = hrl.photometer.new_photometer("i1pro", timeout=1)
+
     xyz = device.readTristimulus(n=1, slp=5)
     assert isinstance(xyz, tuple)
     assert len(xyz) == 3

--- a/tests/test_mock_colorimeter.py
+++ b/tests/test_mock_colorimeter.py
@@ -1,0 +1,127 @@
+"""Test that the MockColorimeter class behaves as expected."""
+
+import numpy as np
+import pytest
+
+from hrl.cluts import RGB_to_XYZ, gamma_correct_RGB
+from hrl.photometer.photometer import MockColorimeter
+
+N_TRIPLETS = 20
+rng = np.random.default_rng(0)
+random_triplets = [rng.random(3) for _ in range(N_TRIPLETS)]
+
+from conftest import COLOR_MATRIX, DARK_CHROMATICITY, DEFAULT_GAMMA
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_identity_callable(triplet):
+    # as callable: identity: tristimulus == RGB
+    colorimeter = MockColorimeter(color_mapping=lambda r, g, b: (r, g, b))
+
+    colorimeter.current_triplet = triplet
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), triplet)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_equal_callable(triplet):
+    # as callable: single gamma transformation for all channels
+    colorimeter = MockColorimeter(color_mapping=lambda r, g, b: (r**2.2, g**2.2, b**2.2))
+
+    tristimulus = triplet**2.2
+
+    colorimeter.current_triplet = triplet
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), tristimulus)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_unequal_callable(triplet):
+    # as callable: different gamma transformations per channel
+    colorimeter = MockColorimeter(color_mapping=lambda r, g, b: (r**0.9, g**2.2, b**1.5))
+
+    tristimulus = triplet ** np.array([0.9, 2.2, 1.5])
+
+    colorimeter.current_triplet = triplet
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), tristimulus)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_identity_array(triplet):
+    # as array: 4 columns (intensity_in, R_out, G_out, B_out), identity mapping
+    identity_array = np.repeat(np.linspace(0, 1, 2**8), 4).reshape(-1, 4)
+    colorimeter = MockColorimeter(color_mapping=identity_array)
+
+    colorimeter.current_triplet = triplet
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), triplet)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_identity_clut(identity_clut, triplet):
+    # as full CLUT table (intensity_in, R_out, G_out, B_out, and additional 9 columns for color matrix)
+    colorimeter = MockColorimeter(color_mapping=identity_clut)
+
+    colorimeter.current_triplet = triplet
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), triplet)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_linear_clut(linear_clut, triplet):
+    # as full CLUT table (intensity_in, R_out, G_out, B_out, and additional 9 columns for color matrix)
+    # linear: no gamma, but dark light
+    colorimeter = MockColorimeter(color_mapping=linear_clut)
+
+    colorimeter.current_triplet = triplet
+
+    desired_tristimulus = RGB_to_XYZ(
+        triplet.reshape((1, 1, 3)),
+        color_matrix=np.eye(3),
+        dark_chromaticity=np.diag(DARK_CHROMATICITY),
+    ).flatten()
+
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), desired_tristimulus)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_linear_conversion_clut(linear_conversion_clut, triplet):
+    # as full CLUT table (intensity_in, R_out, G_out, B_out, and additional 9 columns for color matrix)
+    # linear: no gamma, no dark light, but channel crosstalk
+    colorimeter = MockColorimeter(color_mapping=linear_conversion_clut)
+
+    colorimeter.current_triplet = triplet
+
+    desired_tristimulus = RGB_to_XYZ(
+        triplet.reshape((1, 1, 3)), color_matrix=COLOR_MATRIX, dark_chromaticity=np.zeros(3)
+    ).flatten()
+
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), desired_tristimulus)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_nonlinear_clut(nonlinear_clut, triplet):
+    # as full CLUT table (intensity_in, R_out, G_out, B_out, and additional 9 columns for color matrix)
+    # nonlinear: gamma, dark light, and channel crosstalk
+    colorimeter = MockColorimeter(color_mapping=nonlinear_clut)
+
+    colorimeter.current_triplet = triplet
+
+    # compute desired tristimulus using the nonlinear CLUT
+    gamma_corrected = gamma_correct_RGB(triplet.reshape((1, 1, 3)), nonlinear_clut)
+    desired_tristimulus = RGB_to_XYZ(
+        gamma_corrected,
+        color_matrix=COLOR_MATRIX,
+        dark_chromaticity=np.diag(DARK_CHROMATICITY),
+    ).flatten()
+
+    np.testing.assert_array_equal(colorimeter.readTristimulus(), desired_tristimulus)
+
+
+@pytest.mark.parametrize("triplet", random_triplets)
+def test_readLuminance(identity_clut, triplet):
+    # readLuminance() should return the Y tristimulus value from readTristimulus()
+    colorimeter = MockColorimeter(color_mapping=identity_clut)
+
+    colorimeter.current_triplet = triplet
+    tristimulus = colorimeter.readTristimulus()
+    luminance = colorimeter.readLuminance()
+
+    assert luminance == tristimulus[1]  # Y tristimulus value
+    assert np.isclose(luminance, triplet[1])  # Y tristimulus value for identity mapping

--- a/tests/test_mock_colorimeter.py
+++ b/tests/test_mock_colorimeter.py
@@ -30,7 +30,7 @@ def test_equal_callable(triplet):
     tristimulus = triplet**2.2
 
     colorimeter.current_triplet = triplet
-    np.testing.assert_array_equal(colorimeter.readTristimulus(), tristimulus)
+    np.testing.assert_array_almost_equal(colorimeter.readTristimulus(), tristimulus, decimal=12)
 
 
 @pytest.mark.parametrize("triplet", random_triplets)
@@ -41,7 +41,7 @@ def test_unequal_callable(triplet):
     tristimulus = triplet ** np.array([0.9, 2.2, 1.5])
 
     colorimeter.current_triplet = triplet
-    np.testing.assert_array_equal(colorimeter.readTristimulus(), tristimulus)
+    np.testing.assert_array_almost_equal(colorimeter.readTristimulus(), tristimulus, decimal=12)
 
 
 @pytest.mark.parametrize("triplet", random_triplets)

--- a/tests/test_mock_photometer.py
+++ b/tests/test_mock_photometer.py
@@ -6,9 +6,9 @@ import pytest
 from hrl.photometer.photometer import MockPhotometer
 
 
-def test_no_lut(no_lut):
-    # no_lut: luminance == intensity_in (k=1, dark=0, gamma=1)
-    phot = MockPhotometer(luminance_mapping=no_lut)
+def test_identity_lut(identity_lut):
+    # identity_lut: luminance == intensity_in (k=1, dark=0, gamma=1)
+    phot = MockPhotometer(luminance_mapping=identity_lut)
 
     phot.current_intensity = 0.5
     assert phot.readLuminance() == 0.5


### PR DESCRIPTION
Colorimeter returns XYZ tristimulus values. This class has a `readLuminance` method that returns the Y component and a `readTristimulus` method that returns the three values. This last method should be used for color calibration (#38)

The Colorimeter requires a calibration with a reference white patch that lies in its case; the device should be manually put there in its "bed" for calibration. The class forces a calibration every time the device is instantiated. When asking for a new measurement, it internally checks if calibration is required.

I tested it for our usual luminance calibration pipeline, and it works without issues. Typical calibration in the lab is done with n=256 intensity values and 3 repetitions. With these settings, the colorimeter does not require a calibration midway through measurements. And it is actually a bit faster than the Minolta.


This PR may need editing if we merge PR #32 first. In this PR, the instantiation of the Colorimeter (still) occurs in `hrl/hrl.py` 
 
When merged it closes #37 